### PR TITLE
Header와 Body 구현

### DIFF
--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -1,0 +1,18 @@
+package webserver;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class Body {
+    private static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
+
+    private byte[] data;
+
+    private Body(byte[] data) {
+        this.data = data;
+    }
+
+    public static Body create(String bodyText) {
+        return new Body(bodyText.getBytes(DEFAULT_ENCODING));
+    }
+}

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 public class Header {
-
     private String protocolVersion;
     private String statusCode;
     private String statusText;
@@ -25,32 +24,71 @@ public class Header {
     public static Header from(String headerText) {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
 
+        Builder builder = new Builder();
         List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
 
-        String protocolVersion = "";
-        String statusCode = "";
-        String statusText = "";
-        String contentType = "";
-        int contentLength = -1;
 
         for (String splittedHeaderText : splittedHeaderTexts) {
             pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
 
             HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
 
-            if (pair != null) {
-                contentType = pair.getKey().equals("Content-Type") ? pair.getValue() : contentType;
-                contentLength = pair.getKey().equals("Content-Length") ? Integer.parseInt(pair.getValue()) : contentLength;
+            if (pair != null && pair.getKey().equals("Content-Type")) {
+                builder.contentType(pair.getValue());
+            }
+            if (pair != null && pair.getKey().equals("Content-Length")) {
+                builder.contentLength(Integer.parseInt(pair.getValue()));
             }
         }
 
         String[] statusLine = splittedHeaderTexts[0].split(" ");
 
-        protocolVersion = statusLine[0];
-        statusCode = statusLine[1];
-        statusText = statusLine[2];
+        builder.protocolVersion(statusLine[0]);
+        builder.statusCode(statusLine[1]);
+        builder.statusText(statusLine[2]);
 
-        return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String protocolVersion;
+        private String statusCode;
+        private String statusText;
+        private String contentType;
+        private int contentLength;
+
+        public Builder protocolVersion(String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder statusCode(String statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder statusText(String statusText) {
+            this.statusText = statusText;
+            return this;
+        }
+
+        public Builder contentType(String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public Builder contentLength(int contentLength) {
+            this.contentLength = contentLength;
+            return this;
+        }
+
+        public Header build() {
+            return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
+        }
     }
 
     @Override

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -1,28 +1,84 @@
 package webserver;
 
-import java.util.Objects;
+import util.HttpRequestUtils;
 
-public class Header {
-    private String protocolVersion;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-    public Header(String protocolVersion) {
-        this.protocolVersion = protocolVersion;
+public abstract class Header {
+    protected static final String PROTOCOL_VERSION_KEY = "protocolVersion";
+
+    protected Map<String, String> statusLineAttributes;
+    private Map<String, String> attributes;
+
+    public Header(Map<String, String> attributes) {
+        this.attributes = attributes;
+        this.statusLineAttributes = new HashMap<>();
     }
 
-    public String getProtocolVersion() {
-        return protocolVersion;
+    public static Header of(String headerText, String type) {
+        Map<String, String> attributes = attributeFrom(headerText);
+
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        Header header = of(attributes, type);
+        header.putStatusLine(statusLine);
+
+        return header;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Header header = (Header) o;
-        return Objects.equals(protocolVersion, header.protocolVersion);
+    private static Header of(Map<String, String> attributes, String type) {
+        switch (type) {
+            case "request":
+                return new RequestHeader(attributes);
+            case "response":
+                return new ResponseHeader(attributes);
+            default:
+                throw new IllegalStateException("Unexpected value: " + type);
+        }
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(protocolVersion);
+    private static Map<String, String> attributeFrom(String headerText) {
+        Map<String, String> attributes = new LinkedHashMap<>();
+
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null) {
+                attributes.put(pair.getKey(), pair.getValue());
+            }
+        }
+
+        return attributes;
     }
+
+    protected abstract void putStatusLine(String[] statusLine);
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public Map<String, String> getStatusLineAttributes() {
+        return statusLineAttributes;
+    }
+
+    public byte[] toByte() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(statusLine()).append(System.lineSeparator());
+
+        for (Map.Entry<String, String> entry : getAttributes().entrySet()) {
+            sb.append(entry.getKey() + ": " + entry.getValue() + System.lineSeparator());
+        }
+
+        sb.append(System.lineSeparator());
+
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    protected abstract String statusLine();
 }

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -9,6 +9,10 @@ public class Header {
         this.protocolVersion = protocolVersion;
     }
 
+    public String getProtocolVersion() {
+        return protocolVersion;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -1,0 +1,68 @@
+package webserver;
+
+import util.HttpRequestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Header {
+
+    private String protocolVersion;
+    private String statusCode;
+    private String statusText;
+    private String contentType;
+    private int contentLength;
+
+    public Header(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
+        this.protocolVersion = protocolVersion;
+        this.statusCode = statusCode;
+        this.statusText = statusText;
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+    }
+
+    public static Header from(String headerText) {
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+
+        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
+
+        String protocolVersion = "";
+        String statusCode = "";
+        String statusText = "";
+        String contentType = "";
+        int contentLength = -1;
+
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
+
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null) {
+                contentType = pair.getKey().equals("Content-Type") ? pair.getValue() : contentType;
+                contentLength = pair.getKey().equals("Content-Length") ? Integer.parseInt(pair.getValue()) : contentLength;
+            }
+        }
+
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        protocolVersion = statusLine[0];
+        statusCode = statusLine[1];
+        statusText = statusLine[2];
+
+        return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Header header = (Header) o;
+        return contentLength == header.contentLength && Objects.equals(protocolVersion, header.protocolVersion) && Objects.equals(statusCode, header.statusCode) && Objects.equals(statusText, header.statusText) && Objects.equals(contentType, header.contentType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(protocolVersion, statusCode, statusText, contentType, contentLength);
+    }
+}

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -1,94 +1,12 @@
 package webserver;
 
-import util.HttpRequestUtils;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 public class Header {
     private String protocolVersion;
-    private String statusCode;
-    private String statusText;
-    private String contentType;
-    private int contentLength;
 
-    public Header(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
+    public Header(String protocolVersion) {
         this.protocolVersion = protocolVersion;
-        this.statusCode = statusCode;
-        this.statusText = statusText;
-        this.contentType = contentType;
-        this.contentLength = contentLength;
-    }
-
-    public static Header from(String headerText) {
-        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
-
-        Builder builder = new Builder();
-        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
-
-
-        for (String splittedHeaderText : splittedHeaderTexts) {
-            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
-
-            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
-
-            if (pair != null && pair.getKey().equals("Content-Type")) {
-                builder.contentType(pair.getValue());
-            }
-            if (pair != null && pair.getKey().equals("Content-Length")) {
-                builder.contentLength(Integer.parseInt(pair.getValue()));
-            }
-        }
-
-        String[] statusLine = splittedHeaderTexts[0].split(" ");
-
-        builder.protocolVersion(statusLine[0]);
-        builder.statusCode(statusLine[1]);
-        builder.statusText(statusLine[2]);
-
-        return builder.build();
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private String protocolVersion;
-        private String statusCode;
-        private String statusText;
-        private String contentType;
-        private int contentLength;
-
-        public Builder protocolVersion(String protocolVersion) {
-            this.protocolVersion = protocolVersion;
-            return this;
-        }
-
-        public Builder statusCode(String statusCode) {
-            this.statusCode = statusCode;
-            return this;
-        }
-
-        public Builder statusText(String statusText) {
-            this.statusText = statusText;
-            return this;
-        }
-
-        public Builder contentType(String contentType) {
-            this.contentType = contentType;
-            return this;
-        }
-
-        public Builder contentLength(int contentLength) {
-            this.contentLength = contentLength;
-            return this;
-        }
-
-        public Header build() {
-            return new Header(protocolVersion, statusCode, statusText, contentType, contentLength);
-        }
     }
 
     @Override
@@ -96,11 +14,11 @@ public class Header {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Header header = (Header) o;
-        return contentLength == header.contentLength && Objects.equals(protocolVersion, header.protocolVersion) && Objects.equals(statusCode, header.statusCode) && Objects.equals(statusText, header.statusText) && Objects.equals(contentType, header.contentType);
+        return Objects.equals(protocolVersion, header.protocolVersion);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(protocolVersion, statusCode, statusText, contentType, contentLength);
+        return Objects.hash(protocolVersion);
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,8 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +21,11 @@ public class RequestHandler extends Thread {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+
+            BufferedReader br = new BufferedReader(new InputStreamReader(in));
+
+            log.debug("Request Message:"+ br.lines().collect(Collectors.joining(System.lineSeparator())));
+
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
             byte[] body = "Hello World".getBytes();

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -2,6 +2,7 @@ package webserver;
 
 import util.HttpRequestUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -87,6 +88,28 @@ public class RequestHeader extends Header {
         public RequestHeader build() {
             return new RequestHeader(protocolVersion, cookie, method, path, host);
         }
+    }
+
+    private String startLine() {
+        return method + " " + path + " " + super.getProtocolVersion();
+    }
+
+    private String host() {
+        return "Host: " + host;
+    }
+
+    private String cookie() {
+        return "Cookie: " + cookie;
+    }
+
+    public byte[] toByte() {
+        return new StringBuilder()
+                .append(startLine()).append(System.lineSeparator())
+                .append(host()).append(System.lineSeparator())
+                .append(cookie()).append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .toString()
+                .getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -1,0 +1,105 @@
+package webserver;
+
+import util.HttpRequestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class RequestHeader extends Header {
+    private String cookie;
+    private String method;
+    private String path;
+    private String host;
+
+    public RequestHeader(String protocolVersion, String cookie, String method, String path, String host) {
+        super(protocolVersion);
+        this.cookie = cookie;
+        this.method = method;
+        this.path = path;
+        this.host = host;
+    }
+
+    public static RequestHeader from(String headerText) {
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+
+        Builder builder = new Builder();
+        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
+
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
+
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null && pair.getKey().equals("Host")) {
+                builder.host(pair.getValue());
+            }
+            if (pair != null && pair.getKey().equals("Cookie")) {
+                builder.cookie(pair.getValue());
+            }
+        }
+
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        builder.method(statusLine[0]);
+        builder.path(statusLine[1]);
+        builder.protocolVersion(statusLine[2]);
+
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String protocolVersion;
+        private String cookie;
+        private String method;
+        private String path;
+        private String host;
+
+        public Builder protocolVersion(String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder cookie(String cookie) {
+            this.cookie = cookie;
+            return this;
+        }
+
+        public Builder method(String method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder host(String host) {
+            this.host = host;
+            return this;
+        }
+
+        public RequestHeader build() {
+            return new RequestHeader(protocolVersion, cookie, method, path, host);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        RequestHeader that = (RequestHeader) o;
+        return Objects.equals(cookie, that.cookie) && Objects.equals(method, that.method) && Objects.equals(path, that.path) && Objects.equals(host, that.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), cookie, method, path, host);
+    }
+}

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -1,0 +1,105 @@
+package webserver;
+
+import util.HttpRequestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ResponseHeader extends Header {
+    private String statusCode;
+    private String statusText;
+    private String contentType;
+    private int contentLength;
+
+    public ResponseHeader(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
+        super(protocolVersion);
+        this.statusCode = statusCode;
+        this.statusText = statusText;
+        this.contentType = contentType;
+        this.contentLength = contentLength;
+    }
+
+    public static Header from(String headerText) {
+        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
+
+        Builder builder = new Builder();
+        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
+
+        for (String splittedHeaderText : splittedHeaderTexts) {
+            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
+
+            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
+
+            if (pair != null && pair.getKey().equals("Content-Type")) {
+                builder.contentType(pair.getValue());
+            }
+            if (pair != null && pair.getKey().equals("Content-Length")) {
+                builder.contentLength(Integer.parseInt(pair.getValue()));
+            }
+        }
+
+        String[] statusLine = splittedHeaderTexts[0].split(" ");
+
+        builder.protocolVersion(statusLine[0]);
+        builder.statusCode(statusLine[1]);
+        builder.statusText(statusLine[2]);
+
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private String protocolVersion;
+        private String statusCode;
+        private String statusText;
+        private String contentType;
+        private int contentLength;
+
+        public Builder protocolVersion(String protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder statusCode(String statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder statusText(String statusText) {
+            this.statusText = statusText;
+            return this;
+        }
+
+        public Builder contentType(String contentType) {
+            this.contentType = contentType;
+            return this;
+        }
+
+        public Builder contentLength(int contentLength) {
+            this.contentLength = contentLength;
+            return this;
+        }
+
+        public ResponseHeader build() {
+            return new ResponseHeader(protocolVersion, statusCode, statusText, contentType, contentLength);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ResponseHeader that = (ResponseHeader) o;
+        return contentLength == that.contentLength && Objects.equals(statusCode, that.statusCode) && Objects.equals(statusText, that.statusText) && Objects.equals(contentType, that.contentType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), statusCode, statusText, contentType, contentLength);
+    }
+}

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -1,128 +1,24 @@
 package webserver;
 
-import util.HttpRequestUtils;
-
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 public class ResponseHeader extends Header {
-    private String statusCode;
-    private String statusText;
-    private String contentType;
-    private int contentLength;
+    private static final String STATUS_CODE_KEY = "statusCode";
+    private static final String STATUS_TEXT_KEY = "statusText";
 
-    public ResponseHeader(String protocolVersion, String statusCode, String statusText, String contentType, int contentLength) {
-        super(protocolVersion);
-        this.statusCode = statusCode;
-        this.statusText = statusText;
-        this.contentType = contentType;
-        this.contentLength = contentLength;
-    }
-
-    public static ResponseHeader from(String headerText) {
-        String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
-
-        Builder builder = new Builder();
-        List<HttpRequestUtils.Pair> pairs = new ArrayList<>();
-
-        for (String splittedHeaderText : splittedHeaderTexts) {
-            pairs.add(HttpRequestUtils.parseHeader(splittedHeaderText));
-
-            HttpRequestUtils.Pair pair = HttpRequestUtils.parseHeader(splittedHeaderText);
-
-            if (pair != null && pair.getKey().equals("Content-Type")) {
-                builder.contentType(pair.getValue());
-            }
-            if (pair != null && pair.getKey().equals("Content-Length")) {
-                builder.contentLength(Integer.parseInt(pair.getValue()));
-            }
-        }
-
-        String[] statusLine = splittedHeaderTexts[0].split(" ");
-
-        builder.protocolVersion(statusLine[0]);
-        builder.statusCode(statusLine[1]);
-        builder.statusText(statusLine[2]);
-
-        return builder.build();
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private String protocolVersion;
-        private String statusCode;
-        private String statusText;
-        private String contentType;
-        private int contentLength;
-
-        public Builder protocolVersion(String protocolVersion) {
-            this.protocolVersion = protocolVersion;
-            return this;
-        }
-
-        public Builder statusCode(String statusCode) {
-            this.statusCode = statusCode;
-            return this;
-        }
-
-        public Builder statusText(String statusText) {
-            this.statusText = statusText;
-            return this;
-        }
-
-        public Builder contentType(String contentType) {
-            this.contentType = contentType;
-            return this;
-        }
-
-        public Builder contentLength(int contentLength) {
-            this.contentLength = contentLength;
-            return this;
-        }
-
-        public ResponseHeader build() {
-            return new ResponseHeader(protocolVersion, statusCode, statusText, contentType, contentLength);
-        }
-    }
-
-    private String statusLine() {
-        return super.getProtocolVersion() + " " + statusCode + " " + statusText + " ";
-    }
-
-    private String contentType() {
-        return "Content-Type: " + contentType;
-    }
-
-    private String contentLength() {
-        return "Content-Length: " + contentLength;
-    }
-
-    public byte[] toByte() {
-        return new StringBuilder()
-                .append(statusLine()).append(System.lineSeparator())
-                .append(contentType()).append(System.lineSeparator())
-                .append(contentLength()).append(System.lineSeparator())
-                .append(System.lineSeparator())
-                .toString()
-                .getBytes(StandardCharsets.UTF_8);
+    public ResponseHeader(Map<String, String> attributes) {
+        super(attributes);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-        ResponseHeader that = (ResponseHeader) o;
-        return contentLength == that.contentLength && Objects.equals(statusCode, that.statusCode) && Objects.equals(statusText, that.statusText) && Objects.equals(contentType, that.contentType);
+    protected void putStatusLine(String[] statusLine) {
+        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine[0]);
+        statusLineAttributes.put(STATUS_CODE_KEY, statusLine[1]);
+        statusLineAttributes.put(STATUS_TEXT_KEY, statusLine[2]);
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), statusCode, statusText, contentType, contentLength);
+    protected String statusLine() {
+        return statusLineAttributes.get(PROTOCOL_VERSION_KEY) + " " + statusLineAttributes.get(STATUS_CODE_KEY) + " " + statusLineAttributes.get(STATUS_TEXT_KEY);
     }
 }

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -2,6 +2,7 @@ package webserver;
 
 import util.HttpRequestUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -20,7 +21,7 @@ public class ResponseHeader extends Header {
         this.contentLength = contentLength;
     }
 
-    public static Header from(String headerText) {
+    public static ResponseHeader from(String headerText) {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
 
         Builder builder = new Builder();
@@ -87,6 +88,28 @@ public class ResponseHeader extends Header {
         public ResponseHeader build() {
             return new ResponseHeader(protocolVersion, statusCode, statusText, contentType, contentLength);
         }
+    }
+
+    private String statusLine() {
+        return super.getProtocolVersion() + " " + statusCode + " " + statusText + " ";
+    }
+
+    private String contentType() {
+        return "Content-Type: " + contentType;
+    }
+
+    private String contentLength() {
+        return "Content-Length: " + contentLength;
+    }
+
+    public byte[] toByte() {
+        return new StringBuilder()
+                .append(statusLine()).append(System.lineSeparator())
+                .append(contentType()).append(System.lineSeparator())
+                .append(contentLength()).append(System.lineSeparator())
+                .append(System.lineSeparator())
+                .toString()
+                .getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/src/test/java/webserver/BodyTest.java
+++ b/src/test/java/webserver/BodyTest.java
@@ -1,0 +1,14 @@
+package webserver;
+
+import org.junit.jupiter.api.Test;
+
+class BodyTest {
+
+    @Test
+    void init() {
+        String data = "Hello World";
+        Body expected = Body.create(data);
+
+        Body body = Body.create(data);
+    }
+}

--- a/src/test/java/webserver/HeaderTest.java
+++ b/src/test/java/webserver/HeaderTest.java
@@ -1,38 +1,4 @@
 package webserver;
 
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class HeaderTest {
-
-    @ParameterizedTest
-    @MethodSource
-    void from(String headerText, Header expectedHeader) {
-        assertThat(Header.from(headerText))
-                .isEqualTo(expectedHeader);
-    }
-
-    @SuppressWarnings("unused")
-    static Stream<Arguments> from() {
-        return Stream.of(
-                Arguments.of(
-                        "HTTP/1.1 200 OK " + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                                System.lineSeparator(),
-                        Header.builder()
-                                .protocolVersion("HTTP/1.1")
-                                .statusCode("200")
-                                .statusText("OK")
-                                .contentType("text/html;charset=utf-8")
-                                .contentLength("Hello World".getBytes().length)
-                                .build()
-                )
-        );
-    }
 }

--- a/src/test/java/webserver/HeaderTest.java
+++ b/src/test/java/webserver/HeaderTest.java
@@ -25,14 +25,13 @@ class HeaderTest {
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-//                        Header.builder()
-//                                .protocolVersion("HTTP/1.1")
-//                                .statusCode("200")
-//                                .statusText("OK")
-//                                .contentType("text/html;charset=utf-8")
-//                                .contentLength("Hello World".getL())
-//                                .build()
-                        new Header("HTTP/1.1", "200", "OK", "text/html;charset=utf-8", "Hello World".getBytes().length)
+                        Header.builder()
+                                .protocolVersion("HTTP/1.1")
+                                .statusCode("200")
+                                .statusText("OK")
+                                .contentType("text/html;charset=utf-8")
+                                .contentLength("Hello World".getBytes().length)
+                                .build()
                 )
         );
     }

--- a/src/test/java/webserver/HeaderTest.java
+++ b/src/test/java/webserver/HeaderTest.java
@@ -1,0 +1,39 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HeaderTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void from(String headerText, Header expectedHeader) {
+        assertThat(Header.from(headerText))
+                .isEqualTo(expectedHeader);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+//                        Header.builder()
+//                                .protocolVersion("HTTP/1.1")
+//                                .statusCode("200")
+//                                .statusText("OK")
+//                                .contentType("text/html;charset=utf-8")
+//                                .contentLength("Hello World".getL())
+//                                .build()
+                        new Header("HTTP/1.1", "200", "OK", "text/html;charset=utf-8", "Hello World".getBytes().length)
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -5,20 +5,25 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class RequestHeaderTest {
+
     @ParameterizedTest
     @MethodSource
-    void from(String headerText, RequestHeader expectedHeader) {
-        assertThat(RequestHeader.from(headerText))
-                .isEqualTo(expectedHeader);
+    void getAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(Header.of(headerText, "request").getAttributes())
+                .isEqualTo(expectedAttributes);
     }
 
     @SuppressWarnings("unused")
-    static Stream<Arguments> from() {
+    static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
@@ -37,13 +42,59 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator(),
-                        RequestHeader.builder()
-                                .protocolVersion("HTTP/1.1")
-                                .method("GET")
-                                .path("/")
-                                .cookie("Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443")
-                                .host("localhost:8080")
-                                .build()
+                        new LinkedHashMap() {{
+                            put("Host", "localhost:8080");
+                            put("Connection", "keep-alive");
+                            put("Cache-Control", "max-age=0");
+                            put("sec-ch-ua", "\"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"");
+                            put("sec-ch-ua-mobile", "?0");
+                            put("Upgrade-Insecure-Requests", "1");
+                            put("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36");
+                            put("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9");
+                            put("Sec-Fetch-Site", "none");
+                            put("Sec-Fetch-Mode", "navigate");
+                            put("Sec-Fetch-User", "?1");
+                            put("Sec-Fetch-Dest", "document");
+                            put("Accept-Encoding", "gzip, deflate, br");
+                            put("Accept-Language", "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7");
+                            put("Cookie", "Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443");
+                        }}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(Header.of(headerText, "request").getStatusLineAttributes())
+                .isEqualTo(expectedAttributes);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> getStatusLineAttributes() {
+        return Stream.of(
+                Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        new HashMap() {{
+                            put("method", "GET");
+                            put("path", "/");
+                            put("protocolVersion", "HTTP/1.1");
+                        }}
                 )
         );
     }
@@ -51,8 +102,13 @@ class RequestHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        assertThat(RequestHeader.from(headerText).toByte())
-                .isEqualTo(expectedHeaderByte);
+        byte[] headerByte = Header.of(headerText, "request").toByte();
+
+        assertAll(
+                () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
+                () -> assertThat(new String(headerByte)).isEqualTo(new String(expectedHeaderByte))
+        );
+
     }
 
     @SuppressWarnings("unused")
@@ -78,6 +134,19 @@ class RequestHeaderTest {
                                 System.lineSeparator(),
                         ("GET / HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
                 )

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +44,42 @@ class RequestHeaderTest {
                                 .cookie("Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443")
                                 .host("localhost:8080")
                                 .build()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void toByte(String headerText, byte[] expectedHeaderByte) {
+        assertThat(RequestHeader.from(headerText).toByte())
+                .isEqualTo(expectedHeaderByte);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> toByte() {
+        return Stream.of(
+                Arguments.of(
+                        "GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        ("GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
                 )
         );
     }

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -1,0 +1,49 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequestHeaderTest {
+    @ParameterizedTest
+    @MethodSource
+    void from(String headerText, RequestHeader expectedHeader) {
+        assertThat(RequestHeader.from(headerText))
+                .isEqualTo(expectedHeader);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        RequestHeader.builder()
+                                .protocolVersion("HTTP/1.1")
+                                .method("GET")
+                                .path("/")
+                                .cookie("Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443")
+                                .host("localhost:8080")
+                                .build()
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -1,0 +1,37 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResponseHeaderTest {
+    @ParameterizedTest
+    @MethodSource
+    void from(String headerText, ResponseHeader expectedHeader) {
+        assertThat(ResponseHeader.from(headerText))
+                .isEqualTo(expectedHeader);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+                        ResponseHeader.builder()
+                                .protocolVersion("HTTP/1.1")
+                                .statusCode("200")
+                                .statusText("OK")
+                                .contentType("text/html;charset=utf-8")
+                                .contentLength("Hello World".getBytes().length)
+                                .build()
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,6 +32,29 @@ class ResponseHeaderTest {
                                 .contentType("text/html;charset=utf-8")
                                 .contentLength("Hello World".getBytes().length)
                                 .build()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void toByte(String headerText, byte[] expectedHeaderByte) {
+        assertThat(ResponseHeader.from(headerText).toByte())
+                .isEqualTo(expectedHeaderByte);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> toByte() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+                        ("HTTP/1.1 200 OK " + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
                 )
         );
     }

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -5,33 +5,58 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
-    void from(String headerText, ResponseHeader expectedHeader) {
-        assertThat(ResponseHeader.from(headerText))
-                .isEqualTo(expectedHeader);
+    void getAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(ResponseHeader.of(headerText, "response").getAttributes())
+                .isEqualTo(expectedAttributes);
     }
 
     @SuppressWarnings("unused")
-    static Stream<Arguments> from() {
+    static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-                        ResponseHeader.builder()
-                                .protocolVersion("HTTP/1.1")
-                                .statusCode("200")
-                                .statusText("OK")
-                                .contentType("text/html;charset=utf-8")
-                                .contentLength("Hello World".getBytes().length)
-                                .build()
+                        new LinkedHashMap() {{
+                            put("Content-Type", "text/html;charset=utf-8");
+                            put("Content-Length", String.valueOf("Hello World".getBytes().length));
+                        }}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
+        assertThat(Header.of(headerText, "response").getStatusLineAttributes())
+                .isEqualTo(expectedAttributes);
+    }
+
+    @SuppressWarnings("unused")
+    static Stream<Arguments> getStatusLineAttributes() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator(),
+                        new HashMap() {{
+                            put("protocolVersion", "HTTP/1.1");
+                            put("statusText", "OK");
+                            put("statusCode", "200");
+                        }}
                 )
         );
     }
@@ -39,19 +64,23 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        assertThat(ResponseHeader.from(headerText).toByte())
-                .isEqualTo(expectedHeaderByte);
+        byte[] headerByte = Header.of(headerText, "response").toByte();
+
+        assertAll(
+                () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
+                () -> assertThat(new String(headerByte)).isEqualTo(new String(expectedHeaderByte))
+        );
     }
 
     @SuppressWarnings("unused")
     static Stream<Arguments> toByte() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK " + System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-                        ("HTTP/1.1 200 OK " + System.lineSeparator() +
+                        ("HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator()).getBytes(StandardCharsets.UTF_8)


### PR DESCRIPTION
## `Body` 클래스 구현

- http post 메시지와 reponse 메시지에서 사용할 `Body`객체 구현
- 아직 사용하는 곳이 없어서, 간단하게 작성 됨.

## `Header` 클래스 구현

- http 메시지의 header 부분을 표현
- attribute는 `Map`에 저장했음. 헤더의 항목들을 일일이 필드로 저장하기에는 한계가 있다고 판단됨. 
    - 예를 들어, 실제로 request로 들어오는 헤더는 항목이 아주 많은데, 기존에는 그 중에서 몇 가지만 선별하도록 구현을 했다. 사용하는 헤더가 적으면 크게 문제가 없지만, 필요한 항목이 많아질 수록 코드가 복잡해졌다. 
    - 이를 해결하기위해 a8e355e62e1f464c3a4808d500e2958adc54c4ba 에서 빌더를 추가하는 등의 수정을 했었는데, `Map`을 이용하면 이러한 부분이 자연스럽게 제거돼서 훨씬 깔끔하게 구현할 수 있었다. 
    - 뿐만 아니라, attribute들이 구체적인 필드가 아닌, `Map`으로 추상화되어 있기 때문에 쉽게 추상화 할 수 있었다.
- `Header`를 추상 클래스로 변경하여 중복을 제거하였음.
    - `Map`구조로 변경되었기 때문에 비교적 쉽고 깔끔하게 정리할 수 있었음.
    - `Header`의 정적 팩토리 메소드가 역할 별로 분리 되어 있지만, 결국 하나의 큰 덩어리처럼 느껴진다. 추후 리팩토링을 고려해봐야 할 것 같다.
- `Map<String, String>` 이외에 `List<Pair>`를 고려해볼 수도 있었는데, 그렇게 되면 별개의 클래스로 추출해야 할 것 같아 일단은 `Map`을 사용하기로 했음.

### `RequestHeader`와 `ResponseHeader`

- `Header`를 상속 받는다. 
- 나눈 이유는 
    - status line이 서로 다르기 때문이다. 이를 위해 `Header`에 `statusLineAttributes`를 추가했고, `Header`를 생성할 때 이용했다.
    - 그리고 출력할 때는 `toByte()`를 이용하는데  status line을 가져오는 추상 메서드 이외에는 중복되는 부분이라서 부모 클래스인 `Header`에 정의해줬다. 

## 테스트 코드

-   `RequestHeader`의 테스트 코드는 실제 크롬에서 접속할 때 받아온 헤더를 이용했다.
-   `ResponseHeader`의 테스트 코드는 `RequestHandler`에서 사용하는 텍스트를 이용했다.
-    toByte() 테스트를 실패했을 때 , 육안으로 쉽게 보기 위해 string으로 변환하여 비교하는 코드를 추가했다.