### PR TITLE
Message

### DIFF
--- a/src/main/java/util/HttpRequestUtils.java
+++ b/src/main/java/util/HttpRequestUtils.java
@@ -1,11 +1,12 @@
 package util;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class HttpRequestUtils {
     /**
@@ -51,6 +52,11 @@ public class HttpRequestUtils {
 
     public static Pair parseHeader(String header) {
         return getKeyValue(header, ": ");
+    }
+
+    public static List<String> parseStatusLine(String statusLine) {
+        return Arrays.stream(statusLine.split(" "))
+                .collect(Collectors.toList());
     }
 
     public static class Pair {

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -13,7 +13,7 @@ public class Body {
         this.data = data;
     }
 
-    public static Body create(String bodyText) {
+    public static Body from(String bodyText) {
         return new Body(bodyText.getBytes(DEFAULT_ENCODING));
     }
 

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -29,4 +29,11 @@ public class Body {
     public int hashCode() {
         return Arrays.hashCode(data);
     }
+
+    @Override
+    public String toString() {
+        return "Body{" +
+                "data=" + new String(data) +
+                '}';
+    }
 }

--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -17,6 +17,10 @@ public class Body {
         return new Body(bodyText.getBytes(DEFAULT_ENCODING));
     }
 
+    public String asString() {
+        return new String(data, DEFAULT_ENCODING);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,21 +1,21 @@
 package webserver;
 
 public class GetMessage {
-    private Header header;
+    private RequestHeader header;
 
-    private GetMessage(Header header) {
+    private GetMessage(RequestHeader header) {
         this.header = header;
     }
 
     public static GetMessage from(String getMessage) {
-        return new GetMessage(Header.of(getMessage, "request"));
+        return new GetMessage(Header.requestHeaderFrom(getMessage));
     }
 
-    public Header getHeader() {
+    public RequestHeader getHeader() {
         return header;
     }
 
     public String getMethod() {
-        return ((RequestHeader) header).getMethod();
+        return header.getMethod();
     }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -14,4 +14,8 @@ public class GetMessage {
     public Header getHeader() {
         return header;
     }
+
+    public String getMethod() {
+        return ((RequestHeader) header).getMethod();
+    }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -5,6 +5,7 @@ import util.HttpRequestUtils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Objects;
 
 public class GetMessage implements RequestMessage {
     private RequestHeader header;
@@ -38,5 +39,18 @@ public class GetMessage implements RequestMessage {
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + statusLine.get(RequestHeader.PATH_KEY), e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GetMessage that = (GetMessage) o;
+        return Objects.equals(header, that.header);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(header);
     }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,6 +1,6 @@
 package webserver;
 
-public class GetMessage {
+public class GetMessage implements RequestMessage {
     private RequestHeader header;
 
     private GetMessage(RequestHeader header) {
@@ -11,10 +11,12 @@ public class GetMessage {
         return new GetMessage(Header.requestHeaderFrom(getMessage));
     }
 
+    @Override
     public RequestHeader getHeader() {
         return header;
     }
 
+    @Override
     public String getMethod() {
         return header.getMethod();
     }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,5 +1,11 @@
 package webserver;
 
+import util.HttpRequestUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+
 public class GetMessage implements RequestMessage {
     private RequestHeader header;
 
@@ -19,5 +25,17 @@ public class GetMessage implements RequestMessage {
     @Override
     public String getMethod() {
         return header.getMethod();
+    }
+
+    public Map<String, String> getParameters() {
+        Map<String, String> statusLine = header.getStatusLineAttributes();
+
+        try {
+            URI uri = new URI(statusLine.get(RequestHeader.PATH_KEY));
+            return HttpRequestUtils.parseQueryString(uri.getQuery());
+            
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + statusLine.get(RequestHeader.PATH_KEY), e);
+        }
     }
 }

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -1,0 +1,17 @@
+package webserver;
+
+public class GetMessage {
+    private Header header;
+
+    private GetMessage(Header header) {
+        this.header = header;
+    }
+
+    public static GetMessage from(String getMessage) {
+        return new GetMessage(Header.of(getMessage, "request"));
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+}

--- a/src/main/java/webserver/GetMessage.java
+++ b/src/main/java/webserver/GetMessage.java
@@ -27,13 +27,14 @@ public class GetMessage implements RequestMessage {
         return header.getMethod();
     }
 
+    @Override
     public Map<String, String> getParameters() {
         Map<String, String> statusLine = header.getStatusLineAttributes();
 
         try {
             URI uri = new URI(statusLine.get(RequestHeader.PATH_KEY));
             return HttpRequestUtils.parseQueryString(uri.getQuery());
-            
+
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + statusLine.get(RequestHeader.PATH_KEY), e);
         }

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -25,24 +25,14 @@ public abstract class Header {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
         List<String> statusLine = HttpRequestUtils.parseStatusLine(splittedHeaderTexts[0]);
 
-        Map<String, String> statusLineAttributes = new HashMap<>();
-        statusLineAttributes.put(RequestHeader.METHOD_KEY, statusLine.get(0));
-        statusLineAttributes.put(RequestHeader.PATH_KEY, statusLine.get(1));
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(2));
-
-        return new RequestHeader(statusLineAttributes, attributeFrom(headerText));
+        return RequestHeader.of(statusLine, attributeFrom(headerText));
     }
 
     public static ResponseHeader responseHeaderFrom(String headerText) {
         String[] splittedHeaderTexts = headerText.split(System.lineSeparator());
         List<String> statusLine = HttpRequestUtils.parseStatusLine(splittedHeaderTexts[0]);
 
-        Map<String, String> statusLineAttributes = new HashMap<>();
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(0));
-        statusLineAttributes.put(ResponseHeader.STATUS_CODE_KEY, statusLine.get(1));
-        statusLineAttributes.put(ResponseHeader.STATUS_TEXT_KEY, statusLine.get(2));
-
-        return new ResponseHeader(statusLineAttributes, attributeFrom(headerText));
+        return ResponseHeader.of(statusLine, attributeFrom(headerText));
     }
 
     private static Map<String, String> attributeFrom(String headerText) {

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public abstract class Header {
     protected static final String PROTOCOL_VERSION_KEY = "protocolVersion";
@@ -81,4 +82,17 @@ public abstract class Header {
     }
 
     protected abstract String statusLine();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Header header = (Header) o;
+        return Objects.equals(statusLineAttributes, header.statusLineAttributes) && Objects.equals(attributes, header.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(statusLineAttributes, attributes);
+    }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,10 +1,10 @@
 package webserver;
 
 public class PostMessage {
-    private Header header;
+    private RequestHeader header;
     private Body body;
 
-    public PostMessage(Header header, Body body) {
+    public PostMessage(RequestHeader header, Body body) {
         this.header = header;
         this.body = body;
     }
@@ -12,10 +12,10 @@ public class PostMessage {
     public static PostMessage from(String postMessage) {
         String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
         //TODO body가 비어서 들어오는 경우 실제 form으로 테스트 해서 확인해볼 필요 있음
-        return new PostMessage(Header.of(splittedPostMessage[0], "request"), Body.from(splittedPostMessage[1]));
+        return new PostMessage(Header.requestHeaderFrom(splittedPostMessage[0]), Body.from(splittedPostMessage[1]));
     }
 
-    public Header getHeader() {
+    public RequestHeader getHeader() {
         return header;
     }
 
@@ -24,6 +24,6 @@ public class PostMessage {
     }
 
     public String getMethod() {
-        return ((RequestHeader) header).getMethod();
+        return header.getMethod();
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,6 +1,6 @@
 package webserver;
 
-public class PostMessage {
+public class PostMessage implements RequestMessage {
     private RequestHeader header;
     private Body body;
 
@@ -15,6 +15,7 @@ public class PostMessage {
         return new PostMessage(Header.requestHeaderFrom(splittedPostMessage[0]), Body.from(splittedPostMessage[1]));
     }
 
+    @Override
     public RequestHeader getHeader() {
         return header;
     }
@@ -23,6 +24,7 @@ public class PostMessage {
         return body;
     }
 
+    @Override
     public String getMethod() {
         return header.getMethod();
     }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -11,7 +11,7 @@ public class PostMessage {
 
     public static PostMessage from(String postMessage) {
         String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
-
+        //TODO body가 비어서 들어오는 경우 실제 form으로 테스트 해서 확인해볼 필요 있음
         return new PostMessage(Header.of(splittedPostMessage[0], "request"), Body.from(splittedPostMessage[1]));
     }
 
@@ -21,5 +21,9 @@ public class PostMessage {
 
     public Body getBody() {
         return body;
+    }
+
+    public String getMethod() {
+        return ((RequestHeader) header).getMethod();
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,5 +1,12 @@
 package webserver;
 
+import util.HttpRequestUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
 public class PostMessage implements RequestMessage {
     private RequestHeader header;
     private Body body;
@@ -27,5 +34,15 @@ public class PostMessage implements RequestMessage {
     @Override
     public String getMethod() {
         return header.getMethod();
+    }
+
+
+    public Map<String, String> getParameters() {
+        try {
+            String decode = URLDecoder.decode(body.asString(), StandardCharsets.UTF_8.name());
+            return HttpRequestUtils.parseQueryString(decode);
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("인코딩 오류", e);
+        }
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -36,7 +36,7 @@ public class PostMessage implements RequestMessage {
         return header.getMethod();
     }
 
-
+    @Override
     public Map<String, String> getParameters() {
         try {
             String decode = URLDecoder.decode(body.asString(), StandardCharsets.UTF_8.name());

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -6,6 +6,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
 public class PostMessage implements RequestMessage {
     private RequestHeader header;
@@ -44,5 +45,18 @@ public class PostMessage implements RequestMessage {
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("인코딩 오류", e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PostMessage that = (PostMessage) o;
+        return Objects.equals(header, that.header) && Objects.equals(body, that.body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(header, body);
     }
 }

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -1,0 +1,25 @@
+package webserver;
+
+public class PostMessage {
+    private Header header;
+    private Body body;
+
+    public PostMessage(Header header, Body body) {
+        this.header = header;
+        this.body = body;
+    }
+
+    public static PostMessage from(String postMessage) {
+        String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
+
+        return new PostMessage(Header.of(splittedPostMessage[0], "request"), Body.from(splittedPostMessage[1]));
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+
+    public Body getBody() {
+        return body;
+    }
+}

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -10,6 +10,10 @@ public class RequestHeader extends Header {
         super(attributes);
     }
 
+    public String getMethod() {
+        return getStatusLineAttributes().get(METHOD_KEY);
+    }
+
     @Override
     protected void putStatusLine(String[] statusLine) {
         statusLineAttributes.put(METHOD_KEY, statusLine[0]);

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -5,8 +5,9 @@ import java.util.List;
 import java.util.Map;
 
 public class RequestHeader extends Header {
+    public static final String PATH_KEY = "path";
+
     protected static final String METHOD_KEY = "method";
-    protected static final String PATH_KEY = "path";
 
     protected RequestHeader(Map<String, String> statusLineAttributes, Map<String, String> attributes) {
         super(statusLineAttributes, attributes);

--- a/src/main/java/webserver/RequestHeader.java
+++ b/src/main/java/webserver/RequestHeader.java
@@ -1,24 +1,29 @@
 package webserver;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class RequestHeader extends Header {
-    private static final String METHOD_KEY = "method";
-    private static final String PATH_KEY = "path";
+    protected static final String METHOD_KEY = "method";
+    protected static final String PATH_KEY = "path";
 
-    protected RequestHeader(Map<String, String> attributes) {
-        super(attributes);
+    protected RequestHeader(Map<String, String> statusLineAttributes, Map<String, String> attributes) {
+        super(statusLineAttributes, attributes);
+    }
+
+    public static RequestHeader of(List<String> statusLine, Map<String, String> attributes) {
+        Map<String, String> statusLineAttributes = new HashMap<>();
+
+        statusLineAttributes.put(METHOD_KEY, statusLine.get(0));
+        statusLineAttributes.put(PATH_KEY, statusLine.get(1));
+        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(2));
+
+        return new RequestHeader(statusLineAttributes, attributes);
     }
 
     public String getMethod() {
         return getStatusLineAttributes().get(METHOD_KEY);
-    }
-
-    @Override
-    protected void putStatusLine(String[] statusLine) {
-        statusLineAttributes.put(METHOD_KEY, statusLine[0]);
-        statusLineAttributes.put(PATH_KEY, statusLine[1]);
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine[2]);
     }
 
     @Override

--- a/src/main/java/webserver/RequestMessage.java
+++ b/src/main/java/webserver/RequestMessage.java
@@ -1,0 +1,7 @@
+package webserver;
+
+public interface RequestMessage {
+    RequestHeader getHeader();
+
+    String getMethod();
+}

--- a/src/main/java/webserver/RequestMessage.java
+++ b/src/main/java/webserver/RequestMessage.java
@@ -3,6 +3,16 @@ package webserver;
 import java.util.Map;
 
 public interface RequestMessage {
+    static RequestMessage from(String message) {
+        RequestHeader header = Header.requestHeaderFrom(message.split(System.lineSeparator())[0]);
+
+        if (header.getMethod().equalsIgnoreCase("post")) {
+            return PostMessage.from(message);
+        }
+        
+        return GetMessage.from(message);
+    }
+
     RequestHeader getHeader();
 
     String getMethod();

--- a/src/main/java/webserver/RequestMessage.java
+++ b/src/main/java/webserver/RequestMessage.java
@@ -1,7 +1,11 @@
 package webserver;
 
+import java.util.Map;
+
 public interface RequestMessage {
     RequestHeader getHeader();
 
     String getMethod();
+
+    Map<String, String> getParameters();
 }

--- a/src/main/java/webserver/ResponseHeader.java
+++ b/src/main/java/webserver/ResponseHeader.java
@@ -1,20 +1,25 @@
 package webserver;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class ResponseHeader extends Header {
-    private static final String STATUS_CODE_KEY = "statusCode";
-    private static final String STATUS_TEXT_KEY = "statusText";
+    protected static final String STATUS_CODE_KEY = "statusCode";
+    protected static final String STATUS_TEXT_KEY = "statusText";
 
-    protected ResponseHeader(Map<String, String> attributes) {
-        super(attributes);
+    protected ResponseHeader(Map<String, String> statusLineAttributes, Map<String, String> attributes) {
+        super(statusLineAttributes, attributes);
     }
 
-    @Override
-    protected void putStatusLine(String[] statusLine) {
-        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine[0]);
-        statusLineAttributes.put(STATUS_CODE_KEY, statusLine[1]);
-        statusLineAttributes.put(STATUS_TEXT_KEY, statusLine[2]);
+    public static ResponseHeader of(List<String> statusLine, Map<String, String> attributes) {
+        Map<String, String> statusLineAttributes = new HashMap<>();
+
+        statusLineAttributes.put(PROTOCOL_VERSION_KEY, statusLine.get(0));
+        statusLineAttributes.put(STATUS_CODE_KEY, statusLine.get(1));
+        statusLineAttributes.put(STATUS_TEXT_KEY, statusLine.get(2));
+
+        return new ResponseHeader(statusLineAttributes, attributes);
     }
 
     @Override

--- a/src/main/java/webserver/ResponseMessage.java
+++ b/src/main/java/webserver/ResponseMessage.java
@@ -1,0 +1,25 @@
+package webserver;
+
+public class ResponseMessage {
+    private Header header;
+    private Body body;
+
+    public ResponseMessage(Header header, Body body) {
+        this.header = header;
+        this.body = body;
+    }
+
+    public static ResponseMessage from(String responseMessage) {
+        String[] splittedResponseMessage = responseMessage.split(System.lineSeparator() + System.lineSeparator());
+
+        return new ResponseMessage(Header.of(splittedResponseMessage[0], "response"), Body.from(splittedResponseMessage[1]));
+    }
+
+    public Header getHeader() {
+        return header;
+    }
+
+    public Body getBody() {
+        return body;
+    }
+}

--- a/src/main/java/webserver/ResponseMessage.java
+++ b/src/main/java/webserver/ResponseMessage.java
@@ -1,10 +1,10 @@
 package webserver;
 
 public class ResponseMessage {
-    private Header header;
+    private ResponseHeader header;
     private Body body;
 
-    public ResponseMessage(Header header, Body body) {
+    public ResponseMessage(ResponseHeader header, Body body) {
         this.header = header;
         this.body = body;
     }
@@ -12,10 +12,10 @@ public class ResponseMessage {
     public static ResponseMessage from(String responseMessage) {
         String[] splittedResponseMessage = responseMessage.split(System.lineSeparator() + System.lineSeparator());
 
-        return new ResponseMessage(Header.of(splittedResponseMessage[0], "response"), Body.from(splittedResponseMessage[1]));
+        return new ResponseMessage(Header.responseHeaderFrom(splittedResponseMessage[0]), Body.from(splittedResponseMessage[1]));
     }
 
-    public Header getHeader() {
+    public ResponseHeader getHeader() {
         return header;
     }
 

--- a/src/test/java/util/HttpRequestUtilsTest.java
+++ b/src/test/java/util/HttpRequestUtilsTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import util.HttpRequestUtils.Pair;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -64,6 +66,7 @@ class HttpRequestUtilsTest {
                 Arguments.of("userId=javajigi&password", "javajigi", null)
         );
     }
+
     @ParameterizedTest
     @MethodSource
     void parseCookies(String cookies, String expectedLogined, String expectedJSessionId, String expectedSession) {
@@ -127,6 +130,21 @@ class HttpRequestUtilsTest {
                 Arguments.of(
                         HttpRequestUtils.parseHeader("Content-Length: 59"),
                         new Pair("Content-Length", "59")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parseStatusLine(String statusLine, List<String> expectedParsedStatusLine) {
+        assertThat(HttpRequestUtils.parseStatusLine(statusLine)).isEqualTo(expectedParsedStatusLine);
+    }
+
+    static Stream<Arguments> parseStatusLine() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create HTTP/1.1",
+                        Arrays.asList("GET", "/user/create", "HTTP/1.1")
                 )
         );
     }

--- a/src/test/java/webserver/BodyTest.java
+++ b/src/test/java/webserver/BodyTest.java
@@ -9,9 +9,9 @@ class BodyTest {
     @Test
     void init() {
         String data = "Hello World";
-        Body expectedBody = Body.create(data);
+        Body expectedBody = Body.from(data);
 
-        Body body = Body.create(data);
+        Body body = Body.from(data);
 
         assertThat(body).isEqualTo(expectedBody);
     }

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -55,6 +57,34 @@ class GetMessageTest {
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(),
                         "GET"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getParameters(String messageText, Map<String, String> expectedParameters) {
+        GetMessage getMessage = GetMessage.from(messageText);
+        assertThat(getMessage.getParameters())
+                .isEqualTo(expectedParameters);
+    }
+
+    static Stream<Arguments> getParameters() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(),
+                        new HashMap() {{
+                            put("userId", "javajigi");
+                            put("password", "password");
+                            put("name", "박재성");
+                            put("email", "javajigi@slipp.net");
+                        }}
                 )
         );
     }

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class GetMessageTest {
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getHeader")
     void getHeader(String messageText, RequestHeader expectedRequestHeader) {
         GetMessage getMessage = GetMessage.from(messageText);
 
@@ -41,7 +41,7 @@ class GetMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getMethod")
     void getMethod(String messageText, String expectedRequestMethod) {
         GetMessage getMessage = GetMessage.from(messageText);
         assertThat(getMessage.getMethod()).isEqualTo(expectedRequestMethod);
@@ -62,7 +62,7 @@ class GetMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getParameters")
     void getParameters(String messageText, Map<String, String> expectedParameters) {
         GetMessage getMessage = GetMessage.from(messageText);
         assertThat(getMessage.getParameters())
@@ -79,7 +79,7 @@ class GetMessageTest {
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(),
-                        new HashMap() {{
+                        new HashMap<String, String>() {{
                             put("userId", "javajigi");
                             put("password", "password");
                             put("name", "박재성");

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -27,13 +27,13 @@ class GetMessageTest {
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(),
-                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                        Header.requestHeaderFrom("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
                                 "Content-Length: 59" + System.lineSeparator() +
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator(), "request")
+                                "" + System.lineSeparator())
                 )
         );
     }

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -1,0 +1,39 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class GetMessageTest {
+    @ParameterizedTest
+    @MethodSource
+    void getHeader(String messageText, RequestHeader expectedRequestHeader) {
+        GetMessage getMessage = GetMessage.from(messageText);
+
+        assertThat(getMessage.getHeader()).isEqualTo(expectedRequestHeader);
+    }
+
+    static Stream<Arguments> getHeader() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(),
+                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(), "request")
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/GetMessageTest.java
+++ b/src/test/java/webserver/GetMessageTest.java
@@ -19,6 +19,7 @@ class GetMessageTest {
 
     static Stream<Arguments> getHeader() {
         return Stream.of(
+                //TODO getMessage인데 POST가  성공하는 테스트케이스로 들어가 있음!
                 Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
@@ -33,6 +34,27 @@ class GetMessageTest {
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator(), "request")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getMethod(String messageText, String expectedRequestMethod) {
+        GetMessage getMessage = GetMessage.from(messageText);
+        assertThat(getMessage.getMethod()).isEqualTo(expectedRequestMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of("GET /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(),
+                        "GET"
                 )
         );
     }

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -28,13 +28,13 @@ class PostMessageTest {
                                 "Accept: */*" + System.lineSeparator() +
                                 "" + System.lineSeparator() +
                                 "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
-                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                        Header.requestHeaderFrom("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
                                 "Content-Length: 59" + System.lineSeparator() +
                                 "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
                                 "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator(), "request")
+                                "" + System.lineSeparator())
                 )
         );
     }

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -61,4 +61,26 @@ class PostMessageTest {
                 )
         );
     }
+
+    @ParameterizedTest
+    @MethodSource
+    void getMethod(String messageText, String expectedRequestMethod) {
+        PostMessage postMessage = PostMessage.from(messageText);
+        assertThat(postMessage.getMethod()).isEqualTo(expectedRequestMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        "POST"
+                )
+        );
+    }
 }

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -1,0 +1,64 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class PostMessageTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void getRequestHeader(String messageText, RequestHeader expectedRequestHeader) {
+        PostMessage postMessage = PostMessage.from(messageText);
+
+        assertThat(postMessage.getHeader()).isEqualTo(expectedRequestHeader);
+    }
+
+    static Stream<Arguments> getRequestHeader() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
+                        Header.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator(), "request")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getBody(String messageText, Body expectedBody) {
+        PostMessage postMessage = PostMessage.from(messageText);
+
+        assertThat(postMessage.getBody()).isEqualTo(expectedBody);
+    }
+
+    static Stream<Arguments> getBody() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
+                        Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator())
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class PostMessageTest {
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getHeader")
     void getHeader(String messageText, RequestHeader expectedRequestHeader) {
         PostMessage postMessage = PostMessage.from(messageText);
 
@@ -40,7 +40,7 @@ class PostMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getBody")
     void getBody(String messageText, Body expectedBody) {
         PostMessage postMessage = PostMessage.from(messageText);
 
@@ -63,7 +63,7 @@ class PostMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getMethod")
     void getMethod(String messageText, String expectedRequestMethod) {
         PostMessage postMessage = PostMessage.from(messageText);
         assertThat(postMessage.getMethod()).isEqualTo(expectedRequestMethod);

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -80,6 +82,34 @@ class PostMessageTest {
                                 "" + System.lineSeparator() +
                                 "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                         "POST"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getParameters")
+    void getParameters(String messageText, Map<String, String> expectedParameters) {
+        PostMessage postMessage = PostMessage.from(messageText);
+        assertThat(postMessage.getParameters())
+                .isEqualTo(expectedParameters);
+    }
+
+    static Stream<Arguments> getParameters() {
+        return Stream.of(
+                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        new HashMap<String, String>() {{
+                            put("userId", "javajigi");
+                            put("password", "password");
+                            put("name", "박재성");
+                            put("email", "javajigi@slipp.net");
+                        }}
                 )
         );
     }

--- a/src/test/java/webserver/PostMessageTest.java
+++ b/src/test/java/webserver/PostMessageTest.java
@@ -12,13 +12,13 @@ class PostMessageTest {
 
     @ParameterizedTest
     @MethodSource
-    void getRequestHeader(String messageText, RequestHeader expectedRequestHeader) {
+    void getHeader(String messageText, RequestHeader expectedRequestHeader) {
         PostMessage postMessage = PostMessage.from(messageText);
 
         assertThat(postMessage.getHeader()).isEqualTo(expectedRequestHeader);
     }
 
-    static Stream<Arguments> getRequestHeader() {
+    static Stream<Arguments> getHeader() {
         return Stream.of(
                 Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -18,50 +18,8 @@ class RequestHeaderTest {
     @ParameterizedTest
     @MethodSource
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(Header.of(headerText, "request").getAttributes())
+        assertThat(Header.requestHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
-    }
-
-    @ParameterizedTest
-    @MethodSource
-    void getMethod(String headerText, String expectedMethod) {
-        assertThat(((RequestHeader) Header.of(headerText, "request")).getMethod())
-                .isEqualTo(expectedMethod);
-    }
-
-    static Stream<Arguments> getMethod() {
-        return Stream.of(
-                Arguments.of(
-                        "GET / HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: none" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
-                                System.lineSeparator(),
-                        "GET"
-                ), Arguments.of(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 59" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
-                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                        "POST"
-                )
-        );
     }
 
     @SuppressWarnings("unused")
@@ -107,8 +65,50 @@ class RequestHeaderTest {
 
     @ParameterizedTest
     @MethodSource
+    void getMethod(String headerText, String expectedMethod) {
+        assertThat(Header.requestHeaderFrom(headerText).getMethod())
+                .isEqualTo(expectedMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of(
+                        "GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        "GET"
+                ), Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        "POST"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(Header.of(headerText, "request").getStatusLineAttributes())
+        assertThat(Header.requestHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
@@ -144,7 +144,7 @@ class RequestHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.of(headerText, "request").toByte();
+        byte[] headerByte = Header.requestHeaderFrom(headerText).toByte();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -13,16 +13,16 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+
 class RequestHeaderTest {
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getAttributes")
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.requestHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
@@ -42,7 +42,7 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator(),
-                        new LinkedHashMap() {{
+                        new LinkedHashMap<String, String>() {{
                             put("Host", "localhost:8080");
                             put("Connection", "keep-alive");
                             put("Cache-Control", "max-age=0");
@@ -64,7 +64,7 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getMethod")
     void getMethod(String headerText, String expectedMethod) {
         assertThat(Header.requestHeaderFrom(headerText).getMethod())
                 .isEqualTo(expectedMethod);
@@ -106,13 +106,12 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getStatusLineAttributes")
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.requestHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getStatusLineAttributes() {
         return Stream.of(
                 Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
@@ -132,7 +131,7 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
                                 System.lineSeparator(),
-                        new HashMap() {{
+                        new HashMap<String, String>() {{
                             put("method", "GET");
                             put("path", "/");
                             put("protocolVersion", "HTTP/1.1");
@@ -142,7 +141,7 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("toByte")
     void toByte(String headerText, byte[] expectedHeaderByte) {
         byte[] headerByte = Header.requestHeaderFrom(headerText).toByte();
 
@@ -153,7 +152,6 @@ class RequestHeaderTest {
 
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> toByte() {
         return Stream.of(
                 Arguments.of(

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -22,6 +22,48 @@ class RequestHeaderTest {
                 .isEqualTo(expectedAttributes);
     }
 
+    @ParameterizedTest
+    @MethodSource
+    void getMethod(String headerText, String expectedMethod) {
+        assertThat(((RequestHeader) Header.of(headerText, "request")).getMethod())
+                .isEqualTo(expectedMethod);
+    }
+
+    static Stream<Arguments> getMethod() {
+        return Stream.of(
+                Arguments.of(
+                        "GET / HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: none" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
+                                System.lineSeparator(),
+                        "GET"
+                ), Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        "POST"
+                )
+        );
+    }
+
     @SuppressWarnings("unused")
     static Stream<Arguments> getAttributes() {
         return Stream.of(

--- a/src/test/java/webserver/RequestMessageTest.java
+++ b/src/test/java/webserver/RequestMessageTest.java
@@ -1,0 +1,54 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class RequestMessageTest {
+    @ParameterizedTest
+    @MethodSource("fromGetMessage")
+    void fromGetMessage(String messageText) {
+        assertThat(RequestMessage.from(messageText))
+                .isEqualTo(GetMessage.from(messageText));
+    }
+
+    static Stream<Arguments> fromGetMessage() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("fromPostMessage")
+    void fromPostMessage(String messageText) {
+        assertThat(RequestMessage.from(messageText))
+                .isEqualTo(PostMessage.from(messageText));
+    }
+
+    static Stream<Arguments> fromPostMessage() {
+        return Stream.of(
+                Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net"
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -15,13 +15,12 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ResponseHeaderTest {
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getAttributes")
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.responseHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of(
@@ -29,7 +28,7 @@ class ResponseHeaderTest {
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator(),
-                        new LinkedHashMap() {{
+                        new LinkedHashMap<String, String>() {{
                             put("Content-Type", "text/html;charset=utf-8");
                             put("Content-Length", String.valueOf("Hello World".getBytes().length));
                         }}
@@ -38,13 +37,12 @@ class ResponseHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getStatusLineAttributes")
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
         assertThat(Header.responseHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> getStatusLineAttributes() {
         return Stream.of(
                 Arguments.of(
@@ -62,7 +60,7 @@ class ResponseHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("toByte")
     void toByte(String headerText, byte[] expectedHeaderByte) {
         byte[] headerByte = Header.responseHeaderFrom(headerText).toByte();
 
@@ -72,7 +70,6 @@ class ResponseHeaderTest {
         );
     }
 
-    @SuppressWarnings("unused")
     static Stream<Arguments> toByte() {
         return Stream.of(
                 Arguments.of(

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -17,7 +17,7 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void getAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(ResponseHeader.of(headerText, "response").getAttributes())
+        assertThat(Header.responseHeaderFrom(headerText).getAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
@@ -40,7 +40,7 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void getStatusLineAttributes(String headerText, Map<String, String> expectedAttributes) {
-        assertThat(Header.of(headerText, "response").getStatusLineAttributes())
+        assertThat(Header.responseHeaderFrom(headerText).getStatusLineAttributes())
                 .isEqualTo(expectedAttributes);
     }
 
@@ -64,7 +64,7 @@ class ResponseHeaderTest {
     @ParameterizedTest
     @MethodSource
     void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.of(headerText, "response").toByte();
+        byte[] headerByte = Header.responseHeaderFrom(headerText).toByte();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),

--- a/src/test/java/webserver/ResponseMessageTest.java
+++ b/src/test/java/webserver/ResponseMessageTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class ResponseMessageTest {
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getHeader")
     void getHeader(String messageText, Header expectedRequestHeader) {
         ResponseMessage responseMessage = ResponseMessage.from(messageText);
 
@@ -33,7 +33,7 @@ class ResponseMessageTest {
     }
 
     @ParameterizedTest
-    @MethodSource
+    @MethodSource("getBody")
     void getBody(String messageText, Body expectedBody) {
         ResponseMessage responseMessage = ResponseMessage.from(messageText);
 

--- a/src/test/java/webserver/ResponseMessageTest.java
+++ b/src/test/java/webserver/ResponseMessageTest.java
@@ -25,9 +25,9 @@ class ResponseMessageTest {
                                 "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
                                 System.lineSeparator() +
                                 "Hello World",
-                        Header.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                        Header.responseHeaderFrom("HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator(), "response")
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator())
                 )
         );
     }

--- a/src/test/java/webserver/ResponseMessageTest.java
+++ b/src/test/java/webserver/ResponseMessageTest.java
@@ -1,0 +1,55 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ResponseMessageTest {
+
+    @ParameterizedTest
+    @MethodSource
+    void getHeader(String messageText, Header expectedRequestHeader) {
+        ResponseMessage responseMessage = ResponseMessage.from(messageText);
+
+        assertThat(responseMessage.getHeader()).isEqualTo(expectedRequestHeader);
+    }
+
+    static Stream<Arguments> getHeader() {
+        return Stream.of(
+                Arguments.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator() +
+                                "Hello World",
+                        Header.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator(), "response")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void getBody(String messageText, Body expectedBody) {
+        ResponseMessage responseMessage = ResponseMessage.from(messageText);
+
+        assertThat(responseMessage.getBody()).isEqualTo(expectedBody);
+    }
+
+    static Stream<Arguments> getBody() {
+        return Stream.of(
+                Arguments.of("HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator() +
+                                "Hello World",
+                        Body.from("Hello World")
+                )
+        );
+    }
+
+}


### PR DESCRIPTION
- HTTP 메시지의 형태

  - 헤더가 다르기 때문에 리퀘스트와 리스폰스 메시지로 나눴다.
  - `HttpMessage`로 리퀘스트와 리스폰스를 합치는 방향도 생각해봤는데, 과도한 추상화인 것 같아 그렇게 하지 않았다. Message객체들을 사용할 상위 객체인 `Request`와 `Response`에 필요한 Message의 역할이 서로 다르기 때문이다. 추후 추상화가 가능해보이면 그 때 고려해볼 예정이다.
   ![image](https://user-images.githubusercontent.com/73760074/112925067-381e8b80-914c-11eb-93e8-f907be8e7246.png)
    > 원래 설계의 형태는 위와 같다.



- `RequestMessage`

  - 리퀘스트 메시지는  `Body`의 유무로 나눴다.
  - `Request Message`를 앞으로 사용하는 클래스에서 Get / Post를 유연하게 사용할 수 있도록 인터페이스를 정의하였다.
  - `getParameters()` 은 Get은 path뒤에, Post는 body에 데이터가 포함되기 때문에 형식에 맞게 파싱해서 `Map`으로 리턴해준다.
    - 파싱 된 결과를 필드에 저장하는 방식도 고려해봤는데, 지금은 성능적으로 문제가 없을 것 같아 요청이 올 때마다 데이터를 파싱해서 리턴해주도록 구현했다.

- `GetMessage`

  - 헤더에서 쿼리 스트링을 파싱하는 기능이 메인
  - Status Line에서 path 부분을 가져와서, 쿼리 스트링과 분리를 해주는데 `URI` 클래스에서 `getQuery()` 을 제공해주고, 내부적으로 `decodedQuery` 을 제공해준다.

- `PostMessage`

  - 바디를 파싱하는 기능

  - `Body`의 경우는 주소가 아니기 때문에 `URI`나 `URL`객체를 바로 사용하기는 애매한 것 같아서, `URLDecoder.decode` 를 이용해 퍼센트 인코딩을 디코딩하였다.

    > 예를 들어, `URI`객체에 있는 주소에서 쿼리를 분리해주는 기능을 사용하려면 객체 생성 시 `?name=...`과 같이 작성해야 한다.



- `ResponseMessage`
  - `PostMessage`와 구조가 동일하지만, header가 다르고 추후 내부적으로 동작이 달라질 것 같아서 추상화를 시키지 않았다.

  - header와 body를 나눠주는 기능은 나중에 util로 분리를 고려해볼 수 있을 것 같다.