### PR TITLE
Request and response

### DIFF
--- a/src/main/java/webserver/Body.java
+++ b/src/main/java/webserver/Body.java
@@ -17,8 +17,12 @@ public class Body {
         return new Body(bodyText.getBytes(DEFAULT_ENCODING));
     }
 
-    public String asString() {
+    public String getString() {
         return new String(data, DEFAULT_ENCODING);
+    }
+
+    public byte[] getBytes() {
+        return data;
     }
 
     @Override

--- a/src/main/java/webserver/Header.java
+++ b/src/main/java/webserver/Header.java
@@ -58,7 +58,7 @@ public abstract class Header {
         return statusLineAttributes;
     }
 
-    public byte[] toByte() {
+    public byte[] getBytes() {
         StringBuilder sb = new StringBuilder();
 
         sb.append(statusLine()).append(System.lineSeparator());

--- a/src/main/java/webserver/PostMessage.java
+++ b/src/main/java/webserver/PostMessage.java
@@ -40,7 +40,7 @@ public class PostMessage implements RequestMessage {
     @Override
     public Map<String, String> getParameters() {
         try {
-            String decode = URLDecoder.decode(body.asString(), StandardCharsets.UTF_8.name());
+            String decode = URLDecoder.decode(body.getString(), StandardCharsets.UTF_8.name());
             return HttpRequestUtils.parseQueryString(decode);
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("인코딩 오류", e);

--- a/src/main/java/webserver/Request.java
+++ b/src/main/java/webserver/Request.java
@@ -1,0 +1,30 @@
+package webserver;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+public class Request {
+    private RequestMessage requestMessage;
+
+    private Request(RequestMessage requestMessage) {
+        this.requestMessage = requestMessage;
+    }
+
+    public static Request from(InputStream inputStream){
+
+        try(BufferedReader br = new BufferedReader(new InputStreamReader(inputStream))){
+            String message = br.lines().collect(Collectors.joining(System.lineSeparator()));
+
+            return new Request(RequestMessage.from(message));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("inputStream 이상함.",e);
+        }
+    }
+
+    public RequestMessage getRequestMessage() {
+        return requestMessage;
+    }
+}

--- a/src/main/java/webserver/Response.java
+++ b/src/main/java/webserver/Response.java
@@ -1,0 +1,42 @@
+package webserver;
+
+import java.io.*;
+import java.util.Objects;
+
+public class Response {
+    private ResponseMessage responseMessage;
+
+    public Response(ResponseMessage responseMessage) {
+        this.responseMessage = responseMessage;
+    }
+
+    public static Response from(String message) {
+        return new Response(ResponseMessage.from(message));
+    }
+
+    public void write(OutputStream outputStream) {
+        try (DataOutputStream dos = new DataOutputStream(outputStream)) {
+            byte[] header = responseMessage.getHeader().getBytes();
+            byte[] body = responseMessage.getBody().getBytes();
+
+            dos.write(header);
+            dos.write(body);
+            dos.flush();
+        } catch (IOException e) {
+            throw new IllegalStateException("Response 출력오류", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Response response = (Response) o;
+        return Objects.equals(responseMessage, response.responseMessage);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(responseMessage);
+    }
+}

--- a/src/main/java/webserver/ResponseMessage.java
+++ b/src/main/java/webserver/ResponseMessage.java
@@ -1,5 +1,7 @@
 package webserver;
 
+import java.util.Objects;
+
 public class ResponseMessage {
     private ResponseHeader header;
     private Body body;
@@ -21,5 +23,18 @@ public class ResponseMessage {
 
     public Body getBody() {
         return body;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ResponseMessage that = (ResponseMessage) o;
+        return Objects.equals(header, that.header) && Objects.equals(body, that.body);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(header, body);
     }
 }

--- a/src/test/java/webserver/RequestHeaderTest.java
+++ b/src/test/java/webserver/RequestHeaderTest.java
@@ -141,9 +141,9 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("toByte")
-    void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.requestHeaderFrom(headerText).toByte();
+    @MethodSource("getBytes")
+    void getBytes(String headerText, byte[] expectedHeaderByte) {
+        byte[] headerByte = Header.requestHeaderFrom(headerText).getBytes();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
@@ -152,7 +152,7 @@ class RequestHeaderTest {
 
     }
 
-    static Stream<Arguments> toByte() {
+    static Stream<Arguments> getBytes() {
         return Stream.of(
                 Arguments.of(
                         "GET / HTTP/1.1" + System.lineSeparator() +

--- a/src/test/java/webserver/RequestTest.java
+++ b/src/test/java/webserver/RequestTest.java
@@ -1,0 +1,46 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class RequestTest {
+
+    @ParameterizedTest
+    @MethodSource("from")
+    void from(String inputMessage) {
+        InputStream inputStream = new ByteArrayInputStream(inputMessage.getBytes());
+        Request request = Request.from(inputStream);
+
+        assertThat(request.getRequestMessage()).isEqualTo(RequestMessage.from(inputMessage));
+    }
+
+    static Stream<Arguments> from() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator()
+                ), Arguments.of(
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 59" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "Accept: */*" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net"
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/ResponseHeaderTest.java
+++ b/src/test/java/webserver/ResponseHeaderTest.java
@@ -60,9 +60,9 @@ class ResponseHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("toByte")
-    void toByte(String headerText, byte[] expectedHeaderByte) {
-        byte[] headerByte = Header.responseHeaderFrom(headerText).toByte();
+    @MethodSource("getBytes")
+    void getBytes(String headerText, byte[] expectedHeaderByte) {
+        byte[] headerByte = Header.responseHeaderFrom(headerText).getBytes();
 
         assertAll(
                 () -> assertThat(headerByte).isEqualTo(expectedHeaderByte),
@@ -70,7 +70,7 @@ class ResponseHeaderTest {
         );
     }
 
-    static Stream<Arguments> toByte() {
+    static Stream<Arguments> getBytes() {
         return Stream.of(
                 Arguments.of(
                         "HTTP/1.1 200 OK" + System.lineSeparator() +

--- a/src/test/java/webserver/ResponseTest.java
+++ b/src/test/java/webserver/ResponseTest.java
@@ -1,0 +1,34 @@
+package webserver;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ResponseTest {
+    @ParameterizedTest
+    @MethodSource("write")
+    void write(String message) {
+        Response response = Response.from(message);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        response.write(outputStream);
+        ResponseMessage responseMessage = ResponseMessage.from(outputStream.toString());
+        assertThat(response).isEqualTo(new Response(responseMessage));
+    }
+
+    static Stream<Arguments> write() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK" + System.lineSeparator() +
+                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
+                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
+                                System.lineSeparator() +
+                                "Hello World"
+                )
+        );
+    }
+}


### PR DESCRIPTION
Request

- RequestHandler에서 직접 사용할 객체. 
- connection에서 가져오는 inputStream을 RequestMessage로 바꿔준다.

Response

- 리스폰스 메시지를 받아서, OutputStream 으로 전송. 
- 테스트에서 flush결과를 볼 수 없어 ByteArrayOutputStream을 사용. 
- 비교를 위해 ResponseMessage에 equals 추가함.
