### PR TITLE
Login-freddie

### DIFF
--- a/src/main/java/db/DataBase.java
+++ b/src/main/java/db/DataBase.java
@@ -1,11 +1,11 @@
 package db;
 
+import com.google.common.collect.Maps;
+import model.User;
+
 import java.util.Collection;
 import java.util.Map;
-
-import com.google.common.collect.Maps;
-
-import model.User;
+import java.util.Optional;
 
 public class DataBase {
     private static Map<String, User> users = Maps.newHashMap();
@@ -19,8 +19,8 @@ public class DataBase {
         users.put(user.getUserId(), user);
     }
 
-    public static User findUserById(String userId) {
-        return users.get(userId);
+    public static Optional<User> findUserById(String userId) {
+        return Optional.ofNullable(users.get(userId));
     }
 
     public static Collection<User> findAll() {

--- a/src/main/java/model/PasswordNotMatchException.java
+++ b/src/main/java/model/PasswordNotMatchException.java
@@ -1,0 +1,4 @@
+package model;
+
+public class PasswordNotMatchException extends RuntimeException{
+}

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -15,6 +15,12 @@ public class User {
         this.email = email;
     }
 
+    public void checkPassword(String password) {
+        if (!this.password.equals(password)) {
+            throw new PasswordNotMatchException();
+        }
+    }
+
     public String getUserId() {
         return userId;
     }

--- a/src/main/java/webserver/LoginFailedException.java
+++ b/src/main/java/webserver/LoginFailedException.java
@@ -1,0 +1,11 @@
+package webserver;
+
+public class LoginFailedException extends RuntimeException {
+    public LoginFailedException() {
+        super();
+    }
+
+    public LoginFailedException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -101,10 +101,7 @@ public class RequestHandler extends Thread {
                     responseMessage = loginHandler(parameters);
                 }
             } catch (LoginFailedException loginFailedException) {
-                log.debug("login failed", loginFailedException);
-
-                responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
-                        "Location: http://localhost:8080/login_failed.html";
+                responseMessage = loginFailedExceptionHandler(loginFailedException);
             }
 
             // TODO: 리스폰스 status에 따라 리턴해주는 모듈 작성해볼 수 있을 듯
@@ -131,5 +128,12 @@ public class RequestHandler extends Thread {
                 "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
                 "Location: http://localhost:8080/index.html";
         return responseMessage;
+    }
+
+    private String loginFailedExceptionHandler(LoginFailedException loginFailedException) {
+        log.debug("login failed", loginFailedException);
+
+        return "HTTP/1.1 302 Found" + System.lineSeparator() +
+                "Location: http://localhost:8080/login_failed.html";
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -98,9 +98,11 @@ public class RequestHandler extends Thread {
                 Map<String, String> parameters = request.getRequestMessage().getParameters();
 
                 User user = DataBase.findUserById(parameters.get("userId"));
-                // TODO: 없는 경우 예외처리
 
-                if(user.getPassword().equals(parameters.get("password"))) {
+                if (user == null) {
+                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                            "Location: http://localhost:8080/login_failed.html";
+                } else if (user.getPassword().equals(parameters.get("password"))) {
                     responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
                             "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
                             "Location: http://localhost:8080/index.html";

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -104,6 +104,9 @@ public class RequestHandler extends Thread {
                     responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
                             "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
                             "Location: http://localhost:8080/index.html";
+                } else {
+                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                            "Location: http://localhost:8080/login_failed.html";
                 }
             }
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -94,6 +94,19 @@ public class RequestHandler extends Thread {
                         "Location: http://localhost:8080/index.html";
             }
 
+            if (path.equals("/user/login")) {
+                Map<String, String> parameters = request.getRequestMessage().getParameters();
+
+                User user = DataBase.findUserById(parameters.get("userId"));
+                // TODO: 없는 경우 예외처리
+
+                if(user.getPassword().equals(parameters.get("password"))) {
+                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                            "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
+                            "Location: http://localhost:8080/index.html";
+                }
+            }
+
             Response response = Response.from(responseMessage);
             response.write(out);
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -117,11 +117,8 @@ public class RequestHandler extends Thread {
     }
 
     public String loginHandler(Map<String, String> parameters) {
-        User user = DataBase.findUserById(parameters.get("userId"));
-
-        if (user == null) {
-            throw new LoginFailedException();
-        }
+        User user = DataBase.findUserById(parameters.get("userId"))
+                .orElseThrow(LoginFailedException::new);
 
         try {
             user.checkPassword(parameters.get("password"));

--- a/src/test/java/model/UserTest.java
+++ b/src/test/java/model/UserTest.java
@@ -1,0 +1,52 @@
+package model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+class UserTest {
+
+    @ParameterizedTest
+    @MethodSource("checkPassword")
+    void checkPassword(User user, String password) {
+        user.checkPassword(password);
+    }
+
+    static Stream<Arguments> checkPassword() {
+        return Stream.of(
+                Arguments.arguments(
+                        new User(
+                                "dae",
+                                "dae",
+                                "dae",
+                                "dae@dae.com"
+                        ),
+                        "dae"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("checkPasswordThrowsPasswordNotMatchException")
+    void checkPasswordThrowsPasswordNotMatchException(User user, String password) {
+        Assertions.assertThatExceptionOfType(PasswordNotMatchException.class)
+                .isThrownBy(()->user.checkPassword(password));
+    }
+
+    static Stream<Arguments> checkPasswordThrowsPasswordNotMatchException() {
+        return Stream.of(
+                Arguments.arguments(
+                        new User(
+                                "dae",
+                                "dae",
+                                "dae",
+                                "dae@dae.com"
+                        ),
+                        "dae2"
+                )
+        );
+    }
+}

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -337,7 +337,55 @@ class RequestHandlerTest {
                                 "userId=dae&password=dae2",
                         "HTTP/1.1 302 Found" + System.lineSeparator() +
                                 "Location: http://localhost:8080/login_failed.html" + System.lineSeparator()
-                )// TODO: 실패하는 경우 - null, id, pw
+                ), Arguments.arguments(
+                        "로그인 실패-id다름",
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 48" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=dae&password=dae&name=dae&email=dae%40dae",
+                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 48" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=dae2&password=dae",
+                        "HTTP/1.1 302 Found" + System.lineSeparator() +
+                                "Location: http://localhost:8080/login_failed.html" + System.lineSeparator()
+                )
         );
     }
 }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -289,6 +289,55 @@ class RequestHandlerTest {
                         "HTTP/1.1 302 Found" + System.lineSeparator() +
                                 "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
                                 "Location: http://localhost:8080/index.html" + System.lineSeparator()
-                ));// TODO: 실패하는 경우 추가
+                ), Arguments.arguments(
+                        "로그인 실패-pw다름",
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 48" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=dae&password=dae&name=dae&email=dae%40dae",
+                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 48" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=dae&password=dae2",
+                        "HTTP/1.1 302 Found" + System.lineSeparator() +
+                                "Location: http://localhost:8080/login_failed.html" + System.lineSeparator()
+                )// TODO: 실패하는 경우 - null, id, pw
+        );
     }
 }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -194,4 +194,101 @@ class RequestHandlerTest {
                                 "a=b"
                 ));
     }
+
+    @ParameterizedTest
+    @MethodSource("runWithUserLogin")
+    void runWithUserLogin(String 테스트설명, String registMessage, String loginMessage, String expectedResponseMessage) throws IOException {
+        int port = ThreadLocalRandom.current().nextInt(50000, 60000);
+        ServerSocket server = new ServerSocket(port);
+
+        Socket registBrowser = new Socket("localhost", port);
+
+        RequestHandler registRequestHandler = new RequestHandler(server.accept());
+
+        BufferedOutputStream registBrowserStream = new BufferedOutputStream(registBrowser.getOutputStream());
+
+
+        registBrowserStream.write(registMessage.getBytes(StandardCharsets.UTF_8));
+        registBrowserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        registBrowserStream.flush();
+
+        registRequestHandler.run();
+
+
+        /**
+         * 선수조건으로 회원가입 필요
+         */
+        Socket loginBrowser = new Socket("localhost", port);
+
+        RequestHandler loginRequestHandler = new RequestHandler(server.accept());
+
+        BufferedOutputStream loginBrowserStream = new BufferedOutputStream(loginBrowser.getOutputStream());
+
+
+        loginBrowserStream.write(loginMessage.getBytes(StandardCharsets.UTF_8));
+        loginBrowserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        loginBrowserStream.flush();
+
+        loginRequestHandler.run();
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(loginBrowser.getInputStream()));
+
+        assertThat(br.lines().collect(Collectors.joining(System.lineSeparator())))
+                .describedAs("runWithUserLogin : %s", 테스트설명)
+                .isEqualTo(expectedResponseMessage);
+    }
+
+    static Stream<Arguments> runWithUserLogin() {
+        return Stream.of(
+                Arguments.arguments(
+                        "로그인 성공",
+                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 48" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=dae&password=dae&name=dae&email=dae%40dae",
+                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 48" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=dae&password=dae",
+                        "HTTP/1.1 302 Found" + System.lineSeparator() +
+                                "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
+                                "Location: http://localhost:8080/index.html" + System.lineSeparator()
+                ));
+    }
 }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -11,6 +11,8 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -382,6 +384,37 @@ class RequestHandlerTest {
                                 "userId=dae2&password=dae",
                         "HTTP/1.1 302 Found" + System.lineSeparator() +
                                 "Location: http://localhost:8080/login_failed.html" + System.lineSeparator()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("loginHandler")
+    void loginHandler(User user, Map<String, String> parameters, String expectedResponseMessage) {
+        DataBase.addUser(user);
+        RequestHandler requestHandler = new RequestHandler(null);
+
+        String actualResponseMessage = requestHandler.loginHandler(parameters);
+
+        assertThat(actualResponseMessage).isEqualTo(expectedResponseMessage);
+    }
+
+    static Stream<Arguments> loginHandler() {
+        return Stream.of(
+                Arguments.arguments(
+                        new User(
+                                "dae",
+                                "dae",
+                                "dae",
+                                "dae@dae"
+                        ),
+                        new HashMap() {{
+                            put("userId", "dae");
+                            put("password", "dae");
+                        }},
+                        "HTTP/1.1 302 Found" + System.lineSeparator() +
+                                "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
+                                "Location: http://localhost:8080/index.html"
                 )
         );
     }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -289,6 +289,6 @@ class RequestHandlerTest {
                         "HTTP/1.1 302 Found" + System.lineSeparator() +
                                 "Set-Cookie: logined=true; Path=/" + System.lineSeparator() +
                                 "Location: http://localhost:8080/index.html" + System.lineSeparator()
-                ));
+                ));// TODO: 실패하는 경우 추가
     }
 }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -215,9 +215,6 @@ class RequestHandlerTest {
         registRequestHandler.run();
 
 
-        /**
-         * 선수조건으로 회원가입 필요
-         */
         Socket loginBrowser = new Socket("localhost", port);
 
         RequestHandler loginRequestHandler = new RequestHandler(server.accept());

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -125,8 +125,8 @@ class RequestHandlerTest {
         browserStream.flush();
 
         requestHandler.run();
-
-        assertThat(DataBase.findUserById("test")).isEqualTo(expectedUser);
+        // FIXME: 잘못 된 테스트
+        assertThat(DataBase.findUserById("test").get()).isEqualTo(expectedUser);
     }
 
     static Stream<Arguments> runWithCheckUserCreated() {


### PR DESCRIPTION
- [ ] “로그인” 메뉴를 클릭하면 http://localhost:8080/user/login.html 으로 이동해 로그인할 수 있다.
  - [x] 로그인이 성공하면 index.html로 이동
  - [x] 로그인이 실패하면 /user/login_failed.html로 이동해야 한다.
- [x] 회원가입한 사용자로 로그인할 수 있어야 한다.
  - [x] 로그인이 성공하면 cookie를 활용해 로그인 상태를 유지할 수 있어야 한다. 
    - [x] 정상적으로 로그인 되었는지 확인하려면 앞 단계에서 회원가입한 데이터를 유지해야 한다(회원가입할 때 생성한 User 객체를 DataBase.addUser() 메서드를 활용해 RAM 메모리에 저장한다)
  - [x] 로그인이 성공할 경우 요청 header의 Cookie header 값이 logined=true
    ```text
    HTTP/1.1 200 OK
    Content-Type: text/html
    Set-Cookie: logined=true; Path=/
    ```
    > Set-Cookie 설정시 모든 요청에 대해 Cookie 처리가 가능하도록 Path 설정 값을 /(Path=/)로 설정한다.

  - [ ] 로그인이 실패하면 Cookie header 값이 logined=false로 전달되어야 한다.

- [ ] 로그인 후에 get 요청에서 쿠키가 true로 되어야 한다.
  ```text
  GET /index.html HTTP/1.1
  Host: localhost:8080
  Connection: keep-alive
  Accept: */*
  Cookie: logined=true
  ```
