### PR TITLE
Login-노을

### DIFF
--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -93,6 +93,7 @@ public class RequestHandler extends Thread {
 
                 responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
                         "Location: http://localhost:8080/index.html";
+
             }else if (path.equals("/user/login")){
                 Map<String, String> parameters = request.getRequestMessage().getParameters();
                 User findUser = DataBase.findUserById(parameters.get("userId"));
@@ -100,10 +101,20 @@ public class RequestHandler extends Thread {
 
                 if(findUser == null){
                     log.debug("찾은 유저 없음");
+                    responseMessage = "HTTP/1.1 404 NotFound" + System.lineSeparator() +
+                            "Location: http://localhost:8080/login_failed.html" + System.lineSeparator();
                 }
                 else if(findUser.getPassword().equals(parameters.get("password"))){
+                    responseMessage = "HTTP/1.1 200 OK" + System.lineSeparator() +
+                            "Location: http://localhost:8080/index.html" + System.lineSeparator() +
+                            "Set-Cookie: logined=true" + System.lineSeparator();
+
                     log.debug("로그인 성공");
                 }else{
+                    responseMessage = "HTTP/1.1 401 Unauthorized" + System.lineSeparator() +
+                            "Location: http://localhost:8080/login_failed.html" + System.lineSeparator() +
+                            "Set-Cookie: logined=false" + System.lineSeparator();
+
                     log.debug("로그인 실패");
                 }
             }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -89,9 +89,23 @@ public class RequestHandler extends Thread {
                 );
 
                 DataBase.addUser(newUser);
+                log.debug("가입한 User : {}", newUser);
 
                 responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
                         "Location: http://localhost:8080/index.html";
+            }else if (path.equals("/user/login")){
+                Map<String, String> parameters = request.getRequestMessage().getParameters();
+                User findUser = DataBase.findUserById(parameters.get("userId"));
+                log.debug("찾은 User : {}", findUser);
+
+                if(findUser == null){
+                    log.debug("찾은 유저 없음");
+                }
+                else if(findUser.getPassword().equals(parameters.get("password"))){
+                    log.debug("로그인 성공");
+                }else{
+                    log.debug("로그인 실패");
+                }
             }
 
             Response response = Response.from(responseMessage);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -100,19 +100,22 @@ public class RequestHandler extends Thread {
                 log.debug("찾은 User : {}", findUser);
 
                 if(findUser == null){
+                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                            "Location: http://localhost:8080/index.html" + System.lineSeparator();
+
                     log.debug("찾은 유저 없음");
-                    responseMessage = "HTTP/1.1 404 NotFound" + System.lineSeparator() +
-                            "Location: http://localhost:8080/login_failed.html" + System.lineSeparator();
                 }
                 else if(findUser.getPassword().equals(parameters.get("password"))){
-                    responseMessage = "HTTP/1.1 200 OK" + System.lineSeparator() +
-                            "Location: http://localhost:8080/index.html" + System.lineSeparator() +
+                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                            "Content-Type: text/html" + System.lineSeparator() +
+                            "Location: http://localhost:8080/user/list.html" + System.lineSeparator() +
                             "Set-Cookie: logined=true" + System.lineSeparator();
 
                     log.debug("로그인 성공");
                 }else{
-                    responseMessage = "HTTP/1.1 401 Unauthorized" + System.lineSeparator() +
-                            "Location: http://localhost:8080/login_failed.html" + System.lineSeparator() +
+                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                            "Content-Type: text/html" + System.lineSeparator() +
+                            "Location: http://localhost:8080/user/login_failed.html" + System.lineSeparator() +
                             "Set-Cookie: logined=false" + System.lineSeparator();
 
                     log.debug("로그인 실패");

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -89,36 +89,18 @@ public class RequestHandler extends Thread {
                 );
 
                 DataBase.addUser(newUser);
-                log.debug("가입한 User : {}", newUser);
+                responseMessage = response302Header();
 
-                responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
-                        "Location: http://localhost:8080/index.html";
-
-            }else if (path.equals("/user/login")){
+            } else if (path.equals("/user/login")) {
                 Map<String, String> parameters = request.getRequestMessage().getParameters();
                 User findUser = DataBase.findUserById(parameters.get("userId"));
-                log.debug("찾은 User : {}", findUser);
 
-                if(findUser == null){
-                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
-                            "Location: http://localhost:8080/index.html" + System.lineSeparator();
-
-                    log.debug("찾은 유저 없음");
-                }
-                else if(findUser.getPassword().equals(parameters.get("password"))){
-                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
-                            "Content-Type: text/html" + System.lineSeparator() +
-                            "Location: http://localhost:8080/user/list.html" + System.lineSeparator() +
-                            "Set-Cookie: logined=true" + System.lineSeparator();
-
-                    log.debug("로그인 성공");
-                }else{
-                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
-                            "Content-Type: text/html" + System.lineSeparator() +
-                            "Location: http://localhost:8080/user/login_failed.html" + System.lineSeparator() +
-                            "Set-Cookie: logined=false" + System.lineSeparator();
-
-                    log.debug("로그인 실패");
+                if (findUser == null) {
+                    responseMessage = response302Header();
+                } else if (findUser.getPassword().equals(parameters.get("password"))) {
+                    responseMessage = response302HeaderWithCookie("/user/list.html","logined=true");
+                } else {
+                    responseMessage = response302HeaderWithCookie("/user/login_failed.html","logined=false");
                 }
             }
 
@@ -129,4 +111,18 @@ public class RequestHandler extends Thread {
             log.error(e.getMessage(), e);
         }
     }
+
+    private String response302Header() {
+        String responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                "Location: /index.html" + System.lineSeparator();
+        return responseMessage;
+    }
+
+    private String response302HeaderWithCookie(String location, String cookie) {
+        String responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                "Location: "+location+ System.lineSeparator()+
+                "Set-Cookie: "+cookie+"; Path=/";
+        return responseMessage;
+    }
+
 }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -2,6 +2,8 @@ package webserver;
 
 import db.DataBase;
 import model.User;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -18,7 +20,9 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class RequestHandlerTest {
+
     @ParameterizedTest
     @MethodSource("run")
     void run(String message, String expectedResponseMessage) throws IOException {
@@ -53,7 +57,7 @@ class RequestHandlerTest {
                                 "" + System.lineSeparator(),
                         "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: 6903" + System.lineSeparator() +
+                                "Content-Length: 7051" + System.lineSeparator() +
                                 "" + System.lineSeparator() +
                                 Files.lines(new File("./webapp/index.html").toPath())
                                         .collect(Collectors.joining(System.lineSeparator()))
@@ -72,7 +76,7 @@ class RequestHandlerTest {
                                 "" + System.lineSeparator(),
                         "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: 5169" + System.lineSeparator() +
+                                "Content-Length: 5276" + System.lineSeparator() +
                                 "" + System.lineSeparator() +
                                 Files.lines(new File("./webapp/user/form.html").toPath())
                                         .collect(Collectors.joining(System.lineSeparator()))
@@ -100,7 +104,7 @@ class RequestHandlerTest {
                                 "" + System.lineSeparator() +
                                 "userId=dae&password=dae&name=dae&email=dae%40dae",
                         "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: http://localhost:8080/index.html" + System.lineSeparator()
+                                "Location: /index.html" + System.lineSeparator()
                 )
         );
     }
@@ -194,4 +198,150 @@ class RequestHandlerTest {
                                 "a=b"
                 ));
     }
+
+    @ParameterizedTest
+    @MethodSource("로그인_성공_테스트")
+    void 로그인_성공_테스트(String message, String expectedResponseMessage) throws IOException {
+
+        DataBase.addUser(new User("1234","1234","1234","1234@1234"));
+
+        int port = ThreadLocalRandom.current().nextInt(50000, 60000);
+        ServerSocket server = new ServerSocket(port);
+
+        Socket browser = new Socket("localhost", port);
+
+        RequestHandler requestHandler = new RequestHandler(server.accept());
+
+        BufferedOutputStream browserStream = new BufferedOutputStream(browser.getOutputStream());
+
+        browserStream.write(message.getBytes(StandardCharsets.UTF_8));
+        browserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        browserStream.flush();
+
+        requestHandler.run();
+
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(browser.getInputStream()));
+
+        assertThat(br.lines().collect(Collectors.joining(System.lineSeparator()))).isEqualTo(expectedResponseMessage);
+    }
+
+    static Stream<Arguments> 로그인_성공_테스트() {
+        return Stream.of(
+                Arguments.arguments(
+                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 53" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=1234&password=1234",
+
+                                "HTTP/1.1 302 Found" + System.lineSeparator() +
+                                "Location: /user/list.html" + System.lineSeparator() +
+                                "Set-Cookie: logined=true; Path=/" + System.lineSeparator()
+
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("로그인_실패_테스트")
+    void 로그인_실패_테스트(String message, String expectedResponseMessage) throws IOException {
+
+        int port = ThreadLocalRandom.current().nextInt(50000, 60000);
+        ServerSocket server = new ServerSocket(port);
+
+        Socket browser = new Socket("localhost", port);
+
+        RequestHandler requestHandler = new RequestHandler(server.accept());
+
+        BufferedOutputStream browserStream = new BufferedOutputStream(browser.getOutputStream());
+
+        browserStream.write(message.getBytes(StandardCharsets.UTF_8));
+        browserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        browserStream.flush();
+
+        requestHandler.run();
+
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(browser.getInputStream()));
+
+        assertThat(br.lines().collect(Collectors.joining(System.lineSeparator()))).isEqualTo(expectedResponseMessage);
+    }
+
+    static Stream<Arguments> 로그인_실패_테스트() {
+        return Stream.of(
+                Arguments.arguments(
+                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 53" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=1234&password=4321",
+
+                        "HTTP/1.1 302 Found" + System.lineSeparator() +
+                                "Location: /user/login_failed.html" + System.lineSeparator() +
+                                "Set-Cookie: logined=false; Path=/" + System.lineSeparator()
+                ),Arguments.arguments(
+                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
+                                "Host: localhost:8080" + System.lineSeparator() +
+                                "Connection: keep-alive" + System.lineSeparator() +
+                                "Content-Length: 53" + System.lineSeparator() +
+                                "Cache-Control: max-age=0" + System.lineSeparator() +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
+                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
+                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
+                                "Origin: http://localhost:8080" + System.lineSeparator() +
+                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
+                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
+                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
+                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
+                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
+                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
+                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
+                                "" + System.lineSeparator() +
+                                "userId=emptyId&password=emptyPw",
+
+                        "HTTP/1.1 302 Found" + System.lineSeparator() +
+                                "Location: /index.html" + System.lineSeparator()
+                )
+        );
+    }
+
 }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -4,6 +4,7 @@ import db.DataBase;
 import model.User;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class RequestHandlerTest {
-
     @ParameterizedTest
     @MethodSource("run")
     void run(String message, String expectedResponseMessage) throws IOException {
@@ -57,7 +57,7 @@ class RequestHandlerTest {
                                 "" + System.lineSeparator(),
                         "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: 7051" + System.lineSeparator() +
+                                "Content-Length: 6903" + System.lineSeparator() +
                                 "" + System.lineSeparator() +
                                 Files.lines(new File("./webapp/index.html").toPath())
                                         .collect(Collectors.joining(System.lineSeparator()))
@@ -76,7 +76,7 @@ class RequestHandlerTest {
                                 "" + System.lineSeparator(),
                         "HTTP/1.1 200 OK" + System.lineSeparator() +
                                 "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: 5276" + System.lineSeparator() +
+                                "Content-Length: 5169" + System.lineSeparator() +
                                 "" + System.lineSeparator() +
                                 Files.lines(new File("./webapp/user/form.html").toPath())
                                         .collect(Collectors.joining(System.lineSeparator()))
@@ -200,10 +200,10 @@ class RequestHandlerTest {
     }
 
     @ParameterizedTest
-    @MethodSource("로그인_성공_테스트")
-    void 로그인_성공_테스트(String message, String expectedResponseMessage) throws IOException {
+    @MethodSource("로그인_테스트")
+    void 로그인_테스트(String 테스트설명, String message, String expectedResponseMessage) throws IOException {
 
-        DataBase.addUser(new User("1234","1234","1234","1234@1234"));
+        DataBase.addUser(new User("1234", "1234", "1234", "1234@1234"));
 
         int port = ThreadLocalRandom.current().nextInt(50000, 60000);
         ServerSocket server = new ServerSocket(port);
@@ -223,12 +223,13 @@ class RequestHandlerTest {
 
         BufferedReader br = new BufferedReader(new InputStreamReader(browser.getInputStream()));
 
-        assertThat(br.lines().collect(Collectors.joining(System.lineSeparator()))).isEqualTo(expectedResponseMessage);
+        assertThat(br.lines().collect(Collectors.joining(System.lineSeparator()))).describedAs(테스트설명).isEqualTo(expectedResponseMessage);
     }
 
-    static Stream<Arguments> 로그인_성공_테스트() {
+    static Stream<Arguments> 로그인_테스트() {
         return Stream.of(
                 Arguments.arguments(
+                        "로그인성공",
                         "POST /user/login HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
@@ -252,42 +253,12 @@ class RequestHandlerTest {
                                 "" + System.lineSeparator() +
                                 "userId=1234&password=1234",
 
-                                "HTTP/1.1 302 Found" + System.lineSeparator() +
+                        "HTTP/1.1 302 Found" + System.lineSeparator() +
                                 "Location: /user/list.html" + System.lineSeparator() +
                                 "Set-Cookie: logined=true; Path=/" + System.lineSeparator()
-
-                )
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("로그인_실패_테스트")
-    void 로그인_실패_테스트(String message, String expectedResponseMessage) throws IOException {
-
-        int port = ThreadLocalRandom.current().nextInt(50000, 60000);
-        ServerSocket server = new ServerSocket(port);
-
-        Socket browser = new Socket("localhost", port);
-
-        RequestHandler requestHandler = new RequestHandler(server.accept());
-
-        BufferedOutputStream browserStream = new BufferedOutputStream(browser.getOutputStream());
-
-        browserStream.write(message.getBytes(StandardCharsets.UTF_8));
-        browserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
-        browserStream.flush();
-
-        requestHandler.run();
-
-
-        BufferedReader br = new BufferedReader(new InputStreamReader(browser.getInputStream()));
-
-        assertThat(br.lines().collect(Collectors.joining(System.lineSeparator()))).isEqualTo(expectedResponseMessage);
-    }
-
-    static Stream<Arguments> 로그인_실패_테스트() {
-        return Stream.of(
+                ),
                 Arguments.arguments(
+                        "올바르지 않은 비밀번호 테스트",
                         "POST /user/login HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
@@ -314,7 +285,9 @@ class RequestHandlerTest {
                         "HTTP/1.1 302 Found" + System.lineSeparator() +
                                 "Location: /user/login_failed.html" + System.lineSeparator() +
                                 "Set-Cookie: logined=false; Path=/" + System.lineSeparator()
-                ),Arguments.arguments(
+                ),
+                Arguments.arguments(
+                        "유효하지 않은 계정 로그인 테스트",
                         "POST /user/login HTTP/1.1" + System.lineSeparator() +
                                 "Host: localhost:8080" + System.lineSeparator() +
                                 "Connection: keep-alive" + System.lineSeparator() +
@@ -341,7 +314,9 @@ class RequestHandlerTest {
                         "HTTP/1.1 302 Found" + System.lineSeparator() +
                                 "Location: /index.html" + System.lineSeparator()
                 )
+
         );
     }
+
 
 }


### PR DESCRIPTION
- [x] “로그인” 메뉴를 클릭하면 http://localhost:8080/user/login.html 으로 이동해 로그인할 수 있다.
  - [x] 로그인이 성공하면 index.html로 이동
  - [x] 로그인이 실패하면 /user/login_failed.html로 이동해야 한다.
- [x] 회원가입한 사용자로 로그인할 수 있어야 한다.
  - [x] 로그인이 성공하면 cookie를 활용해 로그인 상태를 유지할 수 있어야 한다. 
    - [x] 정상적으로 로그인 되었는지 확인하려면 앞 단계에서 회원가입한 데이터를 유지해야 한다(회원가입할 때 생성한 User 객체를 DataBase.addUser() 메서드를 활용해 RAM 메모리에 저장한다)
  - [x] 로그인이 성공할 경우 요청 header의 Cookie header 값이 logined=true
    ```text
    HTTP/1.1 200 OK
    Content-Type: text/html
    Set-Cookie: logined=true; Path=/
    ```
    > Set-Cookie 설정시 모든 요청에 대해 Cookie 처리가 가능하도록 Path 설정 값을 /(Path=/)로 설정한다.

  - [x] 로그인이 실패하면 Cookie header 값이 logined=false로 전달되어야 한다.

- [x] 로그인 후에 get 요청에서 쿠키가 true로 되어야 한다.
  ```text
  GET /index.html HTTP/1.1
  Host: localhost:8080
  Connection: keep-alive
  Accept: */*
  Cookie: logined=true
  ```
