### PR TITLE
refactor: get없는 메소드에 get 붙여주도록 수정

### DIFF
--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -53,8 +53,8 @@ public class RequestHandler extends Thread {
             // TODO: Default Message를 설정할 수 있을 것 같다.
             String responseMessage = "HTTP/1.1 404 NotFound" + System.lineSeparator() + System.lineSeparator();
 
-            String path = request.path();
-            String extension = request.pathExtension();
+            String path = request.getPath();
+            String extension = request.getPathExtension();
             if (extension.equals("html")) {
 
                 File htmlFile = new File("./webapp" + path);

--- a/src/main/java/webserver/http/Request.java
+++ b/src/main/java/webserver/http/Request.java
@@ -13,16 +13,16 @@ public class Request {
         return new Request(RequestMessage.from(message));
     }
 
-    public String path() {
-        return requestMessage.path();
+    public String getPath() {
+        return requestMessage.getPath();
     }
 
     public RequestMessage getRequestMessage() {
         return requestMessage;
     }
 
-    public String pathExtension() {
-        String path = path();
+    public String getPathExtension() {
+        String path = getPath();
 
         String[] splitPath = path.split("/");
 

--- a/src/main/java/webserver/http/header/Header.java
+++ b/src/main/java/webserver/http/header/Header.java
@@ -35,7 +35,7 @@ public abstract class Header {
     public byte[] getBytes() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(statusLine()).append(System.lineSeparator());
+        sb.append(getStatusLine()).append(System.lineSeparator());
 
         for (Map.Entry<String, String> entry : getAttributes().entrySet()) {
             sb.append(entry.getKey() + ": " + entry.getValue() + System.lineSeparator());
@@ -46,5 +46,5 @@ public abstract class Header {
         return sb.toString().getBytes(StandardCharsets.UTF_8);
     }
 
-    protected abstract String statusLine();
+    protected abstract String getStatusLine();
 }

--- a/src/main/java/webserver/http/header/RequestHeader.java
+++ b/src/main/java/webserver/http/header/RequestHeader.java
@@ -25,20 +25,20 @@ public class RequestHeader extends Header {
         return RequestHeader.of(statusLine, attributeFrom(headerText));
     }
 
-    public String path() {
-        return statusLine.path();
+    public String getPath() {
+        return statusLine.getPath();
     }
 
     public String getMethod() {
-        return statusLine.method();
+        return statusLine.getMethod();
     }
 
     @Override
-    protected String statusLine() {
+    protected String getStatusLine() {
         return statusLine.toString();
     }
 
-    public String queryString() {
-        return statusLine.queryString();
+    public String getQueryString() {
+        return statusLine.getQueryString();
     }
 }

--- a/src/main/java/webserver/http/header/ResponseHeader.java
+++ b/src/main/java/webserver/http/header/ResponseHeader.java
@@ -27,7 +27,7 @@ public class ResponseHeader extends Header {
     }
 
     @Override
-    protected String statusLine() {
+    protected String getStatusLine() {
         return statusLine.toString();
     }
 }

--- a/src/main/java/webserver/http/message/GetMessage.java
+++ b/src/main/java/webserver/http/message/GetMessage.java
@@ -29,7 +29,7 @@ public class GetMessage implements RequestMessage {
 
     @Override
     public Map<String, String> getParameters() {
-        return HttpRequestUtils.parseQueryString(header.queryString());
+        return HttpRequestUtils.parseQueryString(header.getQueryString());
     }
 
     @Override

--- a/src/main/java/webserver/http/message/RequestMessage.java
+++ b/src/main/java/webserver/http/message/RequestMessage.java
@@ -21,7 +21,7 @@ public interface RequestMessage {
 
     Map<String, String> getParameters();
 
-    default String path() {
-        return getHeader().path();
+    default String getPath() {
+        return getHeader().getPath();
     }
 }

--- a/src/main/java/webserver/http/statusline/RequestStatusLine.java
+++ b/src/main/java/webserver/http/statusline/RequestStatusLine.java
@@ -23,31 +23,31 @@ public class RequestStatusLine extends StatusLine {
         return new RequestStatusLine(statusLineAttributes);
     }
 
-    public String method() {
-        return statusLineAttributeBy(METHOD_KEY);
+    public String getMethod() {
+        return getStatusLineAttributeBy(METHOD_KEY);
     }
 
-    private URI uri() {
+    private URI getUri() {
         try {
-            return new URI(statusLineAttributeBy(PATH_KEY));
+            return new URI(getStatusLineAttributeBy(PATH_KEY));
         } catch (URISyntaxException e) {
-            throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + path(), e);
+            throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + getPath(), e);
         }
     }
 
-    public String path() {
-        return uri().getPath();
+    public String getPath() {
+        return getUri().getPath();
     }
 
-    public String queryString() {
-        return Objects.toString(uri().getQuery(), "");
+    public String getQueryString() {
+        return Objects.toString(getUri().getQuery(), "");
     }
 
     @Override
     public String toString() {
-        return new StringJoiner(" ").add(method())
-                                    .add(path())
-                                    .add(protocol())
+        return new StringJoiner(" ").add(getMethod())
+                                    .add(getPath())
+                                    .add(getProtocol())
                                     .toString();
     }
 }

--- a/src/main/java/webserver/http/statusline/ResponseStatusLine.java
+++ b/src/main/java/webserver/http/statusline/ResponseStatusLine.java
@@ -23,19 +23,19 @@ public class ResponseStatusLine extends StatusLine {
         return new ResponseStatusLine(statusLineAttributes);
     }
 
-    public String statusCode() {
-        return statusLineAttributeBy(STATUS_CODE_KEY);
+    public String getStatusCode() {
+        return getStatusLineAttributeBy(STATUS_CODE_KEY);
     }
 
-    public String statusText() {
-        return statusLineAttributeBy(STATUS_TEXT_KEY);
+    public String getStatusText() {
+        return getStatusLineAttributeBy(STATUS_TEXT_KEY);
     }
 
     @Override
     public String toString() {
-        return new StringJoiner(" ").add(protocol())
-                                    .add(statusCode())
-                                    .add(statusText())
+        return new StringJoiner(" ").add(getProtocol())
+                                    .add(getStatusCode())
+                                    .add(getStatusText())
                                     .toString();
     }
 }

--- a/src/main/java/webserver/http/statusline/StatusLine.java
+++ b/src/main/java/webserver/http/statusline/StatusLine.java
@@ -11,11 +11,11 @@ public abstract class StatusLine {
         this.statusLineAttributes = statusLineAttributes;
     }
 
-    public String protocol() {
+    public String getProtocol() {
         return statusLineAttributes.get(PROTOCOL_VERSION_KEY);
     }
 
-    protected String statusLineAttributeBy(String key) {
+    protected String getStatusLineAttributeBy(String key) {
         return statusLineAttributes.get(key);
     }
 }

--- a/src/test/java/webserver/http/RequestTest.java
+++ b/src/test/java/webserver/http/RequestTest.java
@@ -82,14 +82,14 @@ class RequestTest {
 
     @ParameterizedTest
     @MethodSource
-    void path(String desc, GetMessage getMessage, String expectedPath) {
-        String actualPath = new Request(getMessage).path();
+    void getPath(String desc, GetMessage getMessage, String expectedPath) {
+        String actualPath = new Request(getMessage).getPath();
 
         assertThat(actualPath).as(desc)
                               .isEqualTo(expectedPath);
     }
 
-    static Stream<Arguments> path() {
+    static Stream<Arguments> getPath() {
         return Stream.of(
                 Arguments.of(
                         "쿼리스트링이 없는 GET 메세지",
@@ -131,14 +131,14 @@ class RequestTest {
 
 
     @ParameterizedTest
-    @MethodSource("pathExtension")
-    void pathExtension(String desc, Request request, String expectedExtension) {
-        Assertions.assertThat(request.pathExtension())
+    @MethodSource("getPathExtension")
+    void getPathExtension(String desc, Request request, String expectedExtension) {
+        Assertions.assertThat(request.getPathExtension())
                   .as("status line에서 path의 확장자 가져오기 : %s", desc)
                   .isEqualTo(expectedExtension);
     }
 
-    static Stream<Arguments> pathExtension() {
+    static Stream<Arguments> getPathExtension() {
         return Stream.of(
                 Arguments.of(
                         "확장자가 있는 path",

--- a/src/test/java/webserver/http/header/RequestHeaderTest.java
+++ b/src/test/java/webserver/http/header/RequestHeaderTest.java
@@ -199,17 +199,17 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("path")
-    void path(String desc, RequestStatusLine statusLine, String expectedPath) {
+    @MethodSource("getPath")
+    void getPath(String desc, RequestStatusLine statusLine, String expectedPath) {
         RequestHeader requestHeader = new RequestHeader(statusLine, new HashMap<>());
 
-        String actualPath = requestHeader.path();
+        String actualPath = requestHeader.getPath();
 
         assertThat(actualPath).as("리퀘스트 헤더에서 path 가져오기 : %s", desc)
                               .isEqualTo(expectedPath);
     }
 
-    static Stream<Arguments> path() {
+    static Stream<Arguments> getPath() {
         return Stream.of(
                 Arguments.of(
                         "쿼리스트링이 없는 GET 메세지",

--- a/src/test/java/webserver/http/statusline/RequestStatusLineTest.java
+++ b/src/test/java/webserver/http/statusline/RequestStatusLineTest.java
@@ -12,14 +12,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RequestStatusLineTest {
 
     @ParameterizedTest
-    @MethodSource("method")
-    void method(String desc, RequestStatusLine requestStatusLine, String expectedMethod) {
-        assertThat(requestStatusLine.method())
+    @MethodSource("getMethod")
+    void getMethod(String desc, RequestStatusLine requestStatusLine, String expectedMethod) {
+        assertThat(requestStatusLine.getMethod())
                 .as("status line에서 method 가져오기 : %s", desc)
                 .isEqualTo(expectedMethod);
     }
 
-    static Stream<Arguments> method() {
+    static Stream<Arguments> getMethod() {
         return Stream.of(
                 Arguments.of(
                         "GET 메소드",
@@ -36,14 +36,14 @@ class RequestStatusLineTest {
     }
 
     @ParameterizedTest
-    @MethodSource("path")
-    void path(String desc, RequestStatusLine requestStatusLine, String expectedPath) {
-        assertThat(requestStatusLine.path())
+    @MethodSource("getPath")
+    void getPath(String desc, RequestStatusLine requestStatusLine, String expectedPath) {
+        assertThat(requestStatusLine.getPath())
                 .as("status line에서 path 가져오기 : %s", desc)
                 .isEqualTo(expectedPath);
     }
 
-    static Stream<Arguments> path() {
+    static Stream<Arguments> getPath() {
         return Stream.of(
                 Arguments.of(
                         "쿼리스트링이 없는 path",
@@ -70,14 +70,14 @@ class RequestStatusLineTest {
     }
 
     @ParameterizedTest
-    @MethodSource("protocol")
-    void protocol(String desc, RequestStatusLine requestStatusLine, String expectedMethod) {
-        assertThat(requestStatusLine.protocol())
+    @MethodSource("getProtocol")
+    void getProtocol(String desc, RequestStatusLine requestStatusLine, String expectedMethod) {
+        assertThat(requestStatusLine.getProtocol())
                 .as("status line에서 protocol 가져오기 : %s", desc)
                 .isEqualTo(expectedMethod);
     }
 
-    static Stream<Arguments> protocol() {
+    static Stream<Arguments> getProtocol() {
         return Stream.of(
                 Arguments.of(
                         "HTTP/1.1",
@@ -94,14 +94,14 @@ class RequestStatusLineTest {
     }
 
     @ParameterizedTest
-    @MethodSource("queryString")
-    void queryString(String desc, RequestStatusLine requestStatusLine, String expectedQueryString) {
-        assertThat(requestStatusLine.queryString())
+    @MethodSource("getQueryString")
+    void getQueryString(String desc, RequestStatusLine requestStatusLine, String expectedQueryString) {
+        assertThat(requestStatusLine.getQueryString())
                 .as("status line에서 쿼리스트링 가져오기 : %s", desc)
                 .isEqualTo(expectedQueryString);
     }
 
-    static Stream<Arguments> queryString() {
+    static Stream<Arguments> getQueryString() {
         return Stream.of(
                 Arguments.of(
                         "쿼리스트링이 없는 path",

--- a/src/test/java/webserver/http/statusline/ResponseStatusLineTest.java
+++ b/src/test/java/webserver/http/statusline/ResponseStatusLineTest.java
@@ -12,14 +12,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ResponseStatusLineTest {
 
     @ParameterizedTest
-    @MethodSource("statusCode")
-    void statusCode(String desc, ResponseStatusLine responseStatusLineAttributes, String expectedStatusCode) {
-        assertThat(responseStatusLineAttributes.statusCode())
+    @MethodSource("getStatusCode")
+    void getStatusCode(String desc, ResponseStatusLine responseStatusLineAttributes, String expectedStatusCode) {
+        assertThat(responseStatusLineAttributes.getStatusCode())
                 .as("status line에서 status code 가져오기 : %s", desc)
                 .isEqualTo(expectedStatusCode);
     }
 
-    static Stream<Arguments> statusCode() {
+    static Stream<Arguments> getStatusCode() {
         return Stream.of(
                 Arguments.of(
                         "200 OK",
@@ -36,14 +36,14 @@ class ResponseStatusLineTest {
     }
 
     @ParameterizedTest
-    @MethodSource("statusText")
-    void statusText(String desc, ResponseStatusLine responseStatusLineAttributes, String expectedStatusText) {
-        assertThat(responseStatusLineAttributes.statusText())
+    @MethodSource("getStatusText")
+    void getStatusText(String desc, ResponseStatusLine responseStatusLineAttributes, String expectedStatusText) {
+        assertThat(responseStatusLineAttributes.getStatusText())
                 .as("status line에서 status text 가져오기 : %s", desc)
                 .isEqualTo(expectedStatusText);
     }
 
-    static Stream<Arguments> statusText() {
+    static Stream<Arguments> getStatusText() {
         return Stream.of(
                 Arguments.of(
                         "200 OK",
@@ -60,14 +60,14 @@ class ResponseStatusLineTest {
     }
 
     @ParameterizedTest
-    @MethodSource("protocol")
-    void protocol(String desc, ResponseStatusLine responseStatusLine, String expectedMethod) {
-        assertThat(responseStatusLine.protocol())
+    @MethodSource("getProtocol")
+    void getProtocol(String desc, ResponseStatusLine responseStatusLine, String expectedMethod) {
+        assertThat(responseStatusLine.getProtocol())
                 .as("status line에서 protocol 가져오기 : %s", desc)
                 .isEqualTo(expectedMethod);
     }
 
-    static Stream<Arguments> protocol() {
+    static Stream<Arguments> getProtocol() {
         return Stream.of(
                 Arguments.of(
                         "HTTP/1.1",


### PR DESCRIPTION
`path()` 와 같이 명명된 부분을 `getPath()`와 같이 변경

기존 소스와 일관성 맞추기 위함