### PR TITLE
Remove equals

### DIFF
--- a/src/main/java/webserver/http/Body.java
+++ b/src/main/java/webserver/http/Body.java
@@ -2,7 +2,6 @@ package webserver.http;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 public class Body {
     private static final Charset DEFAULT_ENCODING = StandardCharsets.UTF_8;
@@ -23,25 +22,5 @@ public class Body {
 
     public byte[] getBytes() {
         return data;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Body body = (Body) o;
-        return Arrays.equals(data, body.data);
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(data);
-    }
-
-    @Override
-    public String toString() {
-        return "Body{" +
-                "data=" + new String(data) +
-                '}';
     }
 }

--- a/src/main/java/webserver/http/Response.java
+++ b/src/main/java/webserver/http/Response.java
@@ -5,7 +5,6 @@ import webserver.http.message.ResponseMessage;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.Objects;
 
 public class Response {
     private ResponseMessage responseMessage;
@@ -26,18 +25,5 @@ public class Response {
         dos.write(header);
         dos.write(body);
         dos.flush();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Response response = (Response) o;
-        return Objects.equals(responseMessage, response.responseMessage);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(responseMessage);
     }
 }

--- a/src/main/java/webserver/http/message/GetMessage.java
+++ b/src/main/java/webserver/http/message/GetMessage.java
@@ -4,7 +4,6 @@ import util.HttpRequestUtils;
 import webserver.http.header.RequestHeader;
 
 import java.util.Map;
-import java.util.Objects;
 
 public class GetMessage implements RequestMessage {
     private RequestHeader header;
@@ -30,18 +29,5 @@ public class GetMessage implements RequestMessage {
     @Override
     public Map<String, String> getParameters() {
         return HttpRequestUtils.parseQueryString(header.getQueryString());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        GetMessage that = (GetMessage) o;
-        return Objects.equals(header, that.header);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(header);
     }
 }

--- a/src/main/java/webserver/http/message/PostMessage.java
+++ b/src/main/java/webserver/http/message/PostMessage.java
@@ -8,7 +8,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Objects;
 
 public class PostMessage implements RequestMessage {
     private RequestHeader header;
@@ -22,7 +21,7 @@ public class PostMessage implements RequestMessage {
     public static PostMessage from(String postMessage) {
         String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
 
-        Body body = Body.from(splittedPostMessage.length!= 1 ? splittedPostMessage[1] : "");
+        Body body = Body.from(splittedPostMessage.length != 1 ? splittedPostMessage[1] : "");
 
         return new PostMessage(RequestHeader.from(splittedPostMessage[0]), body);
     }
@@ -49,26 +48,5 @@ public class PostMessage implements RequestMessage {
         } catch (UnsupportedEncodingException e) {
             throw new IllegalStateException("인코딩 오류", e);
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        PostMessage that = (PostMessage) o;
-        return Objects.equals(header, that.header) && Objects.equals(body, that.body);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(header, body);
-    }
-
-    @Override
-    public String toString() {
-        return "PostMessage{" +
-                "header=" + header +
-                ", body=" + body +
-                '}';
     }
 }

--- a/src/main/java/webserver/http/message/ResponseMessage.java
+++ b/src/main/java/webserver/http/message/ResponseMessage.java
@@ -3,7 +3,6 @@ package webserver.http.message;
 import webserver.http.Body;
 import webserver.http.header.ResponseHeader;
 
-import java.util.Objects;
 import java.util.StringJoiner;
 
 public class ResponseMessage {

--- a/src/test/java/webserver/http/BodyTest.java
+++ b/src/test/java/webserver/http/BodyTest.java
@@ -13,6 +13,7 @@ class BodyTest {
 
         Body body = Body.from(data);
 
-        assertThat(body).isEqualTo(expectedBody);
+        assertThat(body)
+                .isEqualToComparingFieldByFieldRecursively(expectedBody);
     }
 }

--- a/src/test/java/webserver/http/message/PostMessageTest.java
+++ b/src/test/java/webserver/http/message/PostMessageTest.java
@@ -55,7 +55,8 @@ class PostMessageTest {
     void getBody(String messageText, Body expectedBody) {
         PostMessage postMessage = PostMessage.from(messageText);
 
-        assertThat(postMessage.getBody()).isEqualTo(expectedBody);
+        assertThat(postMessage.getBody())
+                .isEqualToComparingFieldByFieldRecursively(expectedBody);
     }
 
     static Stream<Arguments> getBody() {

--- a/src/test/java/webserver/http/message/ResponseMessageTest.java
+++ b/src/test/java/webserver/http/message/ResponseMessageTest.java
@@ -54,7 +54,8 @@ class ResponseMessageTest {
     void getBody(String messageText, Body expectedBody) {
         ResponseMessage responseMessage = ResponseMessage.from(messageText);
 
-        assertThat(responseMessage.getBody()).isEqualTo(expectedBody);
+        assertThat(responseMessage.getBody())
+                .isEqualToComparingFieldByFieldRecursively(expectedBody);
     }
 
     static Stream<Arguments> getBody() {


### PR DESCRIPTION
현재 불필요한 equals와 hashcode 제거. 추후 필요하면 추가 고려

Request와 Response는 값으로 동등성을 비교하면 안 된다고 판단함.

예를 들어, Request가 생성되면 새로운 커넥션이 만들어졌다고 가정할 수 있을텐데, 해당 경우 내부의 값은 완전히 일치할 수도 있을 것이라 생각함