### PR TITLE
build.gradle에 java compile 시 인코딩 옵션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,8 @@ plugins {
 group = 'com.codesquad'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
 
 repositories {
     mavenCentral()
@@ -21,6 +23,11 @@ dependencies {
 
 }
 
+compileJava {
+    options.encoding = "UTF-8"
+}
+
 test {
+    systemProperty "file.encoding", "UTF-8"
     useJUnitPlatform()
 }


### PR DESCRIPTION
gradle 직접 테스트 하면 에러 발생
`./gradlew test`

내부에 저장된 텍스트가 제대로 인코딩 되지 않는 것으로 추정

컴파일 시 UTF-8 인코딩 적용하도록 build.gradle에 옵션 추가