### PR TITLE
lineSeparator crlf로 변경

### DIFF
--- a/src/main/java/webserver/Const.java
+++ b/src/main/java/webserver/Const.java
@@ -1,0 +1,6 @@
+package webserver;
+
+public interface Const {
+    
+    String CRLF = "\r\n";
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -46,12 +46,12 @@ public class RequestHandler extends Thread {
             int contentLength = Integer.parseInt(requestHeader.getAttributes().getOrDefault("Content-Length", "0"));
             String requestBody = IOUtils.readData(br, contentLength);
 
-            requestMessages.add(System.lineSeparator() + requestBody);
+            requestMessages.add(Const.CRLF + requestBody);
 
             Request request = Request.from(requestMessages.toString());
 
             // TODO: Default Message를 설정할 수 있을 것 같다.
-            String responseMessage = "HTTP/1.1 404 NotFound" + System.lineSeparator() + System.lineSeparator();
+            String responseMessage = "HTTP/1.1 404 NotFound" + Const.CRLF + Const.CRLF;
 
             String path = request.getPath();
             String extension = request.getPathExtension();
@@ -62,10 +62,10 @@ public class RequestHandler extends Thread {
                 if (htmlFile.exists()) {
                     byte[] body = Files.readAllBytes(htmlFile.toPath());
 
-                    responseMessage = "HTTP/1.1 200 OK" + System.lineSeparator() +
-                            "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                            "Content-Length: " + body.length + System.lineSeparator() +
-                            System.lineSeparator() +
+                    responseMessage = "HTTP/1.1 200 OK" + Const.CRLF +
+                            "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                            "Content-Length: " + body.length + Const.CRLF +
+                            Const.CRLF +
                             new String(body);
                 }
             }
@@ -83,7 +83,7 @@ public class RequestHandler extends Thread {
 
                     DataBase.addUser(newUser);
 
-                    responseMessage = "HTTP/1.1 302 Found" + System.lineSeparator() +
+                    responseMessage = "HTTP/1.1 302 Found" + Const.CRLF +
                             "Location: /index.html";
                     break;
                 }
@@ -117,12 +117,12 @@ public class RequestHandler extends Thread {
                 throw new LoginFailedException();
             }
 
-            return "HTTP/1.1 302 Found" + System.lineSeparator() +
-                    "Location: /index.html" + System.lineSeparator() +
+            return "HTTP/1.1 302 Found" + Const.CRLF +
+                    "Location: /index.html" + Const.CRLF +
                     "Set-Cookie: logined=true; Path=/";
         } catch (LoginFailedException loginFailedException) {
-            return "HTTP/1.1 302 Found" + System.lineSeparator() +
-                    "Location: /user/login_failed.html" + System.lineSeparator() +
+            return "HTTP/1.1 302 Found" + Const.CRLF +
+                    "Location: /user/login_failed.html" + Const.CRLF +
                     "Set-Cookie: logined=false; Path=/";
         }
     }

--- a/src/main/java/webserver/http/header/Header.java
+++ b/src/main/java/webserver/http/header/Header.java
@@ -1,5 +1,6 @@
 package webserver.http.header;
 
+import webserver.Const;
 import webserver.http.attribute.Attributes;
 
 import java.nio.charset.StandardCharsets;
@@ -18,13 +19,13 @@ public abstract class Header {
     public byte[] getBytes() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(getStatusLine()).append(System.lineSeparator());
+        sb.append(getStatusLine()).append(Const.CRLF);
 
         String attributesString = attributes.toHeaderText();
 
-        sb.append(attributesString + (!attributesString.isEmpty() ? "\r\n" : ""));
+        sb.append(attributesString + (!attributesString.isEmpty() ? Const.CRLF : ""));
 
-        sb.append(System.lineSeparator());
+        sb.append(Const.CRLF);
 
         return sb.toString().getBytes(StandardCharsets.UTF_8);
     }

--- a/src/main/java/webserver/http/message/PostMessage.java
+++ b/src/main/java/webserver/http/message/PostMessage.java
@@ -1,6 +1,7 @@
 package webserver.http.message;
 
 import util.HttpRequestUtils;
+import webserver.Const;
 import webserver.http.Body;
 import webserver.http.header.RequestHeader;
 
@@ -19,7 +20,7 @@ public class PostMessage implements RequestMessage {
     }
 
     public static PostMessage from(String postMessage) {
-        String[] splittedPostMessage = postMessage.split(System.lineSeparator() + System.lineSeparator());
+        String[] splittedPostMessage = postMessage.split(Const.CRLF + Const.CRLF);
 
         Body body = Body.from(splittedPostMessage.length != 1 ? splittedPostMessage[1] : "");
 

--- a/src/main/java/webserver/http/message/ResponseMessage.java
+++ b/src/main/java/webserver/http/message/ResponseMessage.java
@@ -1,5 +1,6 @@
 package webserver.http.message;
 
+import webserver.Const;
 import webserver.http.Body;
 import webserver.http.header.ResponseHeader;
 
@@ -15,9 +16,9 @@ public class ResponseMessage {
     }
 
     public static ResponseMessage from(String responseMessage) {
-        String[] splittedResponseMessage = responseMessage.split(System.lineSeparator() + System.lineSeparator());
+        String[] splittedResponseMessage = responseMessage.split(Const.CRLF + Const.CRLF);
 
-        StringJoiner body = new StringJoiner(System.lineSeparator() + System.lineSeparator());
+        StringJoiner body = new StringJoiner(Const.CRLF + Const.CRLF);
 
         for (int i = 1; i < splittedResponseMessage.length; i++) {
             body.add(splittedResponseMessage[i]);

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -27,7 +27,8 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static webserver.FileForTest.*;
+import static webserver.FileForTest.FORM_HTML;
+import static webserver.FileForTest.INDEX_HTML;
 
 class RequestHandlerTest {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -80,7 +81,7 @@ class RequestHandlerTest {
 
 
         browserStream.write(message.getBytes(StandardCharsets.UTF_8));
-        browserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        browserStream.write(Const.CRLF.getBytes(StandardCharsets.UTF_8));
         browserStream.flush();
 
         requestHandler.run();
@@ -93,61 +94,61 @@ class RequestHandlerTest {
     static Stream<Arguments> run() throws IOException {
         return Stream.of(
                 Arguments.arguments(
-                        "GET /index.html HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator(),
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + INDEX_HTML.length() + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "GET /index.html HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF,
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + INDEX_HTML.length() + Const.CRLF +
+                                "" + Const.CRLF +
                                 Files.lines(INDEX_HTML.toPath())
                                         .collect(Collectors.joining(System.lineSeparator()))
                 ), Arguments.arguments(
-                        "GET /index2.html HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator(),
-                        "HTTP/1.1 404 NotFound" + System.lineSeparator()
+                        "GET /index2.html HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF,
+                        "HTTP/1.1 404 NotFound" + Const.CRLF
                 ), Arguments.arguments(
-                        "GET /user/form.html HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator(),
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + FORM_HTML.length() + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "GET /user/form.html HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF,
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + FORM_HTML.length() + Const.CRLF +
+                                "" + Const.CRLF +
                                 Files.lines(FORM_HTML.toPath())
                                         .collect(Collectors.joining(System.lineSeparator()))
                 ), Arguments.arguments(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 48" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "Origin: http://localhost:8080" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 48" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "Origin: http://localhost:8080" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: same-origin" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Referer: http://localhost:8080/user/form.html" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "userId=dae&password=dae&name=dae&email=dae%40dae",
-                        "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: /index.html" + System.lineSeparator()
+                        "HTTP/1.1 302 Found" + Const.CRLF +
+                                "Location: /index.html" + Const.CRLF
                 )
         );
     }
@@ -161,7 +162,7 @@ class RequestHandlerTest {
 
 
         browserStream.write(message.getBytes(StandardCharsets.UTF_8));
-        browserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        browserStream.write(Const.CRLF.getBytes(StandardCharsets.UTF_8));
         browserStream.flush();
 
         requestHandler.run();
@@ -172,27 +173,27 @@ class RequestHandlerTest {
     static Stream<Arguments> runWithCheckUserCreated() {
         return Stream.of(
                 Arguments.arguments(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 53" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "Origin: http://localhost:8080" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 53" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "Origin: http://localhost:8080" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: same-origin" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Referer: http://localhost:8080/user/form.html" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "userId=test&password=test&name=test&email=test%40test",
                         User.builder()
                                 .setUserId("test")
@@ -201,10 +202,10 @@ class RequestHandlerTest {
                                 .setEmail("test@test")
                                 .build()
                 ), Arguments.arguments(
-                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator(),
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF,
                         User.builder()
                                 .setUserId("javajigi")
                                 .setPassword("password")
@@ -224,7 +225,7 @@ class RequestHandlerTest {
 
 
         browserStream.write(message.getBytes(StandardCharsets.UTF_8));
-        browserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        browserStream.write(Const.CRLF.getBytes(StandardCharsets.UTF_8));
         browserStream.flush();
 
 
@@ -235,9 +236,9 @@ class RequestHandlerTest {
     static Stream<Arguments> runWithFailToCreateUser() {
         return Stream.of(
                 Arguments.arguments(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Content-Length: 3" + System.lineSeparator() +
-                                System.lineSeparator() +
+                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                "Content-Length: 3" + Const.CRLF +
+                                Const.CRLF +
                                 "a=b"
                 ));
     }
@@ -254,7 +255,7 @@ class RequestHandlerTest {
         BufferedOutputStream browserStream = new BufferedOutputStream(browser.getOutputStream());
 
         browserStream.write(message.getBytes(StandardCharsets.UTF_8));
-        browserStream.write(System.lineSeparator().getBytes(StandardCharsets.UTF_8));
+        browserStream.write(Const.CRLF.getBytes(StandardCharsets.UTF_8));
         browserStream.flush();
 
         requestHandler.run();
@@ -278,31 +279,31 @@ class RequestHandlerTest {
                                 .setName("test")
                                 .setEmail("test@test")
                                 .build(),
-                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 53" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "Origin: http://localhost:8080" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "POST /user/login HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 53" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "Origin: http://localhost:8080" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: same-origin" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Referer: http://localhost:8080/user/form.html" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "userId=test&password=test&name=test&email=test%40test",
-                        "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: /index.html" + System.lineSeparator() +
-                                "Set-Cookie: logined=true; Path=/" + System.lineSeparator()
+                        "HTTP/1.1 302 Found" + Const.CRLF +
+                                "Location: /index.html" + Const.CRLF +
+                                "Set-Cookie: logined=true; Path=/" + Const.CRLF
                 ), Arguments.arguments(
                         "로그인 실패 - 잘못된 아이디",
                         User.builder()
@@ -311,31 +312,31 @@ class RequestHandlerTest {
                                 .setName("test")
                                 .setEmail("test@test")
                                 .build(),
-                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 53" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "Origin: http://localhost:8080" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "POST /user/login HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 53" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "Origin: http://localhost:8080" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: same-origin" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Referer: http://localhost:8080/user/form.html" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "userId=wrongId&password=test&name=test&email=test%40test",
-                        "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: /user/login_failed.html" + System.lineSeparator() +
-                                "Set-Cookie: logined=false; Path=/" + System.lineSeparator()
+                        "HTTP/1.1 302 Found" + Const.CRLF +
+                                "Location: /user/login_failed.html" + Const.CRLF +
+                                "Set-Cookie: logined=false; Path=/" + Const.CRLF
                 ), Arguments.arguments(
                         "로그인 실패 - 잘못된 비밀번호",
                         User.builder()
@@ -344,31 +345,31 @@ class RequestHandlerTest {
                                 .setName("test")
                                 .setEmail("test@test")
                                 .build(),
-                        "POST /user/login HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 53" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "Origin: http://localhost:8080" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: same-origin" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Referer: http://localhost:8080/user/form.html" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "POST /user/login HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 53" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "Origin: http://localhost:8080" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: same-origin" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Referer: http://localhost:8080/user/form.html" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: _ga=GA1.1.773336800.1611186274; Idea-dc7ca9b6=ac856d6e-e872-46ac-b153-000bdad105ec" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "userId=test&password=wrongPw&name=test&email=test%40test",
-                        "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: /user/login_failed.html" + System.lineSeparator() +
-                                "Set-Cookie: logined=false; Path=/" + System.lineSeparator()
+                        "HTTP/1.1 302 Found" + Const.CRLF +
+                                "Location: /user/login_failed.html" + Const.CRLF +
+                                "Set-Cookie: logined=false; Path=/" + Const.CRLF
                 )
         );
     }
@@ -402,8 +403,8 @@ class RequestHandlerTest {
                             put("name", "test");
                             put("email", "test@test");
                         }},
-                        "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: /index.html" + System.lineSeparator() +
+                        "HTTP/1.1 302 Found" + Const.CRLF +
+                                "Location: /index.html" + Const.CRLF +
                                 "Set-Cookie: logined=true; Path=/"
                 ), Arguments.arguments(
                         "로그인 실패 - 잘못된 ID",
@@ -419,8 +420,8 @@ class RequestHandlerTest {
                             put("name", "test");
                             put("email", "test@test");
                         }},
-                        "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: /user/login_failed.html" + System.lineSeparator() +
+                        "HTTP/1.1 302 Found" + Const.CRLF +
+                                "Location: /user/login_failed.html" + Const.CRLF +
                                 "Set-Cookie: logined=false; Path=/"
                 ), Arguments.arguments(
                         "로그인 실패 - 잘못된 비밀번호",
@@ -436,8 +437,8 @@ class RequestHandlerTest {
                             put("name", "test");
                             put("email", "test@test");
                         }},
-                        "HTTP/1.1 302 Found" + System.lineSeparator() +
-                                "Location: /user/login_failed.html" + System.lineSeparator() +
+                        "HTTP/1.1 302 Found" + Const.CRLF +
+                                "Location: /user/login_failed.html" + Const.CRLF +
                                 "Set-Cookie: logined=false; Path=/"
                 )
         );

--- a/src/test/java/webserver/http/RequestTest.java
+++ b/src/test/java/webserver/http/RequestTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 import webserver.http.attribute.Attributes;
 import webserver.http.header.RequestHeader;
 import webserver.http.message.GetMessage;
@@ -30,13 +31,13 @@ class RequestTest {
     static Stream<Arguments> from() {
         return Stream.of(
                 Arguments.of(
-                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
-                        "Host: localhost:8080" + System.lineSeparator() +
-                        "Connection: keep-alive" + System.lineSeparator() +
-                        "Content-Length: 59" + System.lineSeparator() +
-                        "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                        "Accept: */*" + System.lineSeparator() +
-                        "" + System.lineSeparator(),
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                        "Host: localhost:8080" + Const.CRLF +
+                        "Connection: keep-alive" + Const.CRLF +
+                        "Content-Length: 59" + Const.CRLF +
+                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                        "Accept: */*" + Const.CRLF +
+                        "" + Const.CRLF,
                         new GetMessage(RequestHeader.of(
                                 Arrays.asList(
                                         "GET",
@@ -52,13 +53,13 @@ class RequestTest {
                                 }})
                         ))
                 ), Arguments.of(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                        "Host: localhost:8080" + System.lineSeparator() +
-                        "Connection: keep-alive" + System.lineSeparator() +
-                        "Content-Length: 59" + System.lineSeparator() +
-                        "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                        "Accept: */*" + System.lineSeparator() +
-                        "" + System.lineSeparator() +
+                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                        "Host: localhost:8080" + Const.CRLF +
+                        "Connection: keep-alive" + Const.CRLF +
+                        "Content-Length: 59" + Const.CRLF +
+                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                        "Accept: */*" + Const.CRLF +
+                        "" + Const.CRLF +
                         "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                         new PostMessage(
                                 RequestHeader.of(

--- a/src/test/java/webserver/http/ResponseTest.java
+++ b/src/test/java/webserver/http/ResponseTest.java
@@ -3,6 +3,7 @@ package webserver.http;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 import webserver.http.message.ResponseMessage;
 
 import java.io.ByteArrayOutputStream;
@@ -26,16 +27,16 @@ class ResponseTest {
     static Stream<Arguments> write() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                        "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                        "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                        System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                        "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                        "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                        Const.CRLF +
                         "Hello World",
                         new Response(ResponseMessage.from(
-                                "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                                System.lineSeparator() +
+                                "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                Const.CRLF +
                                 "Hello World"
                         ))
                 )

--- a/src/test/java/webserver/http/header/RequestHeaderTest.java
+++ b/src/test/java/webserver/http/header/RequestHeaderTest.java
@@ -3,6 +3,7 @@ package webserver.http.header;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 import webserver.http.attribute.Attributes;
 import webserver.http.statusline.RequestStatusLine;
 
@@ -27,23 +28,23 @@ class RequestHeaderTest {
     static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of(
-                        "GET / HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: none" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
-                                System.lineSeparator(),
+                        "GET / HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: none" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
+                                Const.CRLF,
                         Attributes.from(new LinkedHashMap<String, String>() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -76,32 +77,32 @@ class RequestHeaderTest {
     static Stream<Arguments> getMethod() {
         return Stream.of(
                 Arguments.of(
-                        "GET / HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: none" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
-                                System.lineSeparator(),
+                        "GET / HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: none" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
+                                Const.CRLF,
                         "GET"
                 ), Arguments.of(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 59" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 59" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                         "POST"
                 )
@@ -119,23 +120,23 @@ class RequestHeaderTest {
 
     static Stream<Arguments> getStatusLineAttributes() {
         return Stream.of(
-                Arguments.of("GET / HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: none" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
-                                System.lineSeparator(),
+                Arguments.of("GET / HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: none" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
+                                Const.CRLF,
                         new RequestStatusLine(
                                 new HashMap<String, String>() {{
                                     put("method", "GET");
@@ -162,40 +163,40 @@ class RequestHeaderTest {
     static Stream<Arguments> getBytes() {
         return Stream.of(
                 Arguments.of(
-                        "GET / HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: none" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
-                                System.lineSeparator(),
-                        ("GET / HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Cache-Control: max-age=0" + System.lineSeparator() +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + System.lineSeparator() +
-                                "sec-ch-ua-mobile: ?0" + System.lineSeparator() +
-                                "Upgrade-Insecure-Requests: 1" + System.lineSeparator() +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + System.lineSeparator() +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + System.lineSeparator() +
-                                "Sec-Fetch-Site: none" + System.lineSeparator() +
-                                "Sec-Fetch-Mode: navigate" + System.lineSeparator() +
-                                "Sec-Fetch-User: ?1" + System.lineSeparator() +
-                                "Sec-Fetch-Dest: document" + System.lineSeparator() +
-                                "Accept-Encoding: gzip, deflate, br" + System.lineSeparator() +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + System.lineSeparator() +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + System.lineSeparator() +
-                                System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
+                        "GET / HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: none" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
+                                Const.CRLF,
+                        ("GET / HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Cache-Control: max-age=0" + Const.CRLF +
+                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
+                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
+                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
+                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
+                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
+                                "Sec-Fetch-Site: none" + Const.CRLF +
+                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
+                                "Sec-Fetch-User: ?1" + Const.CRLF +
+                                "Sec-Fetch-Dest: document" + Const.CRLF +
+                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
+                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
+                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
+                                Const.CRLF).getBytes(StandardCharsets.UTF_8)
                 )
         );
     }

--- a/src/test/java/webserver/http/header/ResponseHeaderTest.java
+++ b/src/test/java/webserver/http/header/ResponseHeaderTest.java
@@ -3,6 +3,7 @@ package webserver.http.header;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 import webserver.http.attribute.Attributes;
 import webserver.http.statusline.ResponseStatusLine;
 
@@ -25,10 +26,10 @@ class ResponseHeaderTest {
     static Stream<Arguments> getAttributes() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                                System.lineSeparator(),
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                Const.CRLF,
                         Attributes.from(
                                 new LinkedHashMap<String, String>() {{
                                     put("Content-Type", "text/html;charset=utf-8");
@@ -51,10 +52,10 @@ class ResponseHeaderTest {
     static Stream<Arguments> getStatusLineAttributes() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                                System.lineSeparator(),
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                Const.CRLF,
                         new ResponseStatusLine(
                                 new HashMap() {{
                                     put("protocolVersion", "HTTP/1.1");
@@ -80,14 +81,14 @@ class ResponseHeaderTest {
     static Stream<Arguments> getBytes() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                                System.lineSeparator(),
-                        ("HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                                System.lineSeparator()).getBytes(StandardCharsets.UTF_8)
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                Const.CRLF,
+                        ("HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                Const.CRLF).getBytes(StandardCharsets.UTF_8)
                 )
         );
     }

--- a/src/test/java/webserver/http/message/GetMessageTest.java
+++ b/src/test/java/webserver/http/message/GetMessageTest.java
@@ -3,6 +3,7 @@ package webserver.http.message;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 import webserver.http.header.RequestHeader;
 
 import java.util.HashMap;
@@ -27,21 +28,21 @@ class GetMessageTest {
         return Stream.of(
                 //TODO getMessage인데 POST가  성공하는 테스트케이스로 들어가 있음!
                 Arguments.of(
-                        "GET /user/create HTTP/1.1" + System.lineSeparator() +
-                        "Host: localhost:8080" + System.lineSeparator() +
-                        "Connection: keep-alive" + System.lineSeparator() +
-                        "Content-Length: 59" + System.lineSeparator() +
-                        "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                        "Accept: */*" + System.lineSeparator() +
-                        "" + System.lineSeparator(),
+                        "GET /user/create HTTP/1.1" + Const.CRLF +
+                        "Host: localhost:8080" + Const.CRLF +
+                        "Connection: keep-alive" + Const.CRLF +
+                        "Content-Length: 59" + Const.CRLF +
+                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                        "Accept: */*" + Const.CRLF +
+                        "" + Const.CRLF,
                         RequestHeader.from(
-                                "GET /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 59" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator()
+                                "GET /user/create HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 59" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF
                         )
                 )
         );
@@ -56,13 +57,13 @@ class GetMessageTest {
 
     static Stream<Arguments> getMethod() {
         return Stream.of(
-                Arguments.of("GET /user/create HTTP/1.1" + System.lineSeparator() +
-                             "Host: localhost:8080" + System.lineSeparator() +
-                             "Connection: keep-alive" + System.lineSeparator() +
-                             "Content-Length: 59" + System.lineSeparator() +
-                             "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                             "Accept: */*" + System.lineSeparator() +
-                             "" + System.lineSeparator(),
+                Arguments.of("GET /user/create HTTP/1.1" + Const.CRLF +
+                             "Host: localhost:8080" + Const.CRLF +
+                             "Connection: keep-alive" + Const.CRLF +
+                             "Content-Length: 59" + Const.CRLF +
+                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                             "Accept: */*" + Const.CRLF +
+                             "" + Const.CRLF,
                              "GET"
                 )
         );
@@ -79,13 +80,13 @@ class GetMessageTest {
     static Stream<Arguments> getParameters() {
         return Stream.of(
                 Arguments.of(
-                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
-                        "Host: localhost:8080" + System.lineSeparator() +
-                        "Connection: keep-alive" + System.lineSeparator() +
-                        "Content-Length: 59" + System.lineSeparator() +
-                        "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                        "Accept: */*" + System.lineSeparator() +
-                        "" + System.lineSeparator(),
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                        "Host: localhost:8080" + Const.CRLF +
+                        "Connection: keep-alive" + Const.CRLF +
+                        "Content-Length: 59" + Const.CRLF +
+                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                        "Accept: */*" + Const.CRLF +
+                        "" + Const.CRLF,
                         new HashMap<String, String>() {{
                             put("userId", "javajigi");
                             put("password", "password");

--- a/src/test/java/webserver/http/message/PostMessageTest.java
+++ b/src/test/java/webserver/http/message/PostMessageTest.java
@@ -3,6 +3,7 @@ package webserver.http.message;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 import webserver.http.Body;
 import webserver.http.header.RequestHeader;
 
@@ -28,23 +29,23 @@ class PostMessageTest {
     static Stream<Arguments> getHeader() {
         return Stream.of(
                 Arguments.of(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                        "Host: localhost:8080" + System.lineSeparator() +
-                        "Connection: keep-alive" + System.lineSeparator() +
-                        "Content-Length: 59" + System.lineSeparator() +
-                        "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                        "Accept: */*" + System.lineSeparator() +
-                        "" + System.lineSeparator() +
-                        "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
+                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                        "Host: localhost:8080" + Const.CRLF +
+                        "Connection: keep-alive" + Const.CRLF +
+                        "Content-Length: 59" + Const.CRLF +
+                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                        "Accept: */*" + Const.CRLF +
+                        "" + Const.CRLF +
+                        "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + Const.CRLF,
                         RequestHeader.from(
                                 //TODO: 텍스트가 아닌 객체를 생성해서 테스트 해볼 수 있을 듯 Request의 테스트 참고
-                                "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 59" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator()
+                                "POST /user/create HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 59" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF
                         )
                 )
         );
@@ -61,17 +62,17 @@ class PostMessageTest {
 
     static Stream<Arguments> getBody() {
         return Stream.of(
-                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
-                             "Host: localhost:8080" + System.lineSeparator() +
-                             "Connection: keep-alive" + System.lineSeparator() +
-                             "Content-Length: 59" + System.lineSeparator() +
-                             "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                             "Accept: */*" + System.lineSeparator() +
-                             "" + System.lineSeparator() +
-                             "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator(),
+                Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
+                             "Host: localhost:8080" + Const.CRLF +
+                             "Connection: keep-alive" + Const.CRLF +
+                             "Content-Length: 59" + Const.CRLF +
+                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                             "Accept: */*" + Const.CRLF +
+                             "" + Const.CRLF +
+                             "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + Const.CRLF,
                              Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + System.lineSeparator())
-                ), Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                ), Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "",
                                 Body.from("")
                 )
@@ -87,13 +88,13 @@ class PostMessageTest {
 
     static Stream<Arguments> getMethod() {
         return Stream.of(
-                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
-                             "Host: localhost:8080" + System.lineSeparator() +
-                             "Connection: keep-alive" + System.lineSeparator() +
-                             "Content-Length: 59" + System.lineSeparator() +
-                             "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                             "Accept: */*" + System.lineSeparator() +
-                             "" + System.lineSeparator() +
+                Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
+                             "Host: localhost:8080" + Const.CRLF +
+                             "Connection: keep-alive" + Const.CRLF +
+                             "Content-Length: 59" + Const.CRLF +
+                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                             "Accept: */*" + Const.CRLF +
+                             "" + Const.CRLF +
                              "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                              "POST"
                 )
@@ -110,13 +111,13 @@ class PostMessageTest {
 
     static Stream<Arguments> getParameters() {
         return Stream.of(
-                Arguments.of("POST /user/create HTTP/1.1" + System.lineSeparator() +
-                             "Host: localhost:8080" + System.lineSeparator() +
-                             "Connection: keep-alive" + System.lineSeparator() +
-                             "Content-Length: 59" + System.lineSeparator() +
-                             "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                             "Accept: */*" + System.lineSeparator() +
-                             "" + System.lineSeparator() +
+                Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
+                             "Host: localhost:8080" + Const.CRLF +
+                             "Connection: keep-alive" + Const.CRLF +
+                             "Content-Length: 59" + Const.CRLF +
+                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                             "Accept: */*" + Const.CRLF +
+                             "" + Const.CRLF +
                              "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                              new HashMap<String, String>() {{
                                  put("userId", "javajigi");

--- a/src/test/java/webserver/http/message/RequestMessageTest.java
+++ b/src/test/java/webserver/http/message/RequestMessageTest.java
@@ -3,6 +3,7 @@ package webserver.http.message;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 
 import java.util.stream.Stream;
 
@@ -19,21 +20,21 @@ class RequestMessageTest {
     static Stream<Arguments> fromGetMessage() {
         return Stream.of(
                 Arguments.of(
-                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
-                        "Host: localhost:8080" + System.lineSeparator() +
-                        "Connection: keep-alive" + System.lineSeparator() +
-                        "Content-Length: 59" + System.lineSeparator() +
-                        "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                        "Accept: */*" + System.lineSeparator() +
-                        "" + System.lineSeparator(),
+                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                        "Host: localhost:8080" + Const.CRLF +
+                        "Connection: keep-alive" + Const.CRLF +
+                        "Content-Length: 59" + Const.CRLF +
+                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                        "Accept: */*" + Const.CRLF +
+                        "" + Const.CRLF,
                         GetMessage.from(
-                                "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 59" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator()
+                                "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 59" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF
                         )
                 )
         );
@@ -49,22 +50,22 @@ class RequestMessageTest {
     static Stream<Arguments> fromPostMessage() {
         return Stream.of(
                 Arguments.of(
-                        "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                        "Host: localhost:8080" + System.lineSeparator() +
-                        "Connection: keep-alive" + System.lineSeparator() +
-                        "Content-Length: 59" + System.lineSeparator() +
-                        "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                        "Accept: */*" + System.lineSeparator() +
-                        "" + System.lineSeparator() +
+                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                        "Host: localhost:8080" + Const.CRLF +
+                        "Connection: keep-alive" + Const.CRLF +
+                        "Content-Length: 59" + Const.CRLF +
+                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                        "Accept: */*" + Const.CRLF +
+                        "" + Const.CRLF +
                         "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                         PostMessage.from(
-                                "POST /user/create HTTP/1.1" + System.lineSeparator() +
-                                "Host: localhost:8080" + System.lineSeparator() +
-                                "Connection: keep-alive" + System.lineSeparator() +
-                                "Content-Length: 59" + System.lineSeparator() +
-                                "Content-Type: application/x-www-form-urlencoded" + System.lineSeparator() +
-                                "Accept: */*" + System.lineSeparator() +
-                                "" + System.lineSeparator() +
+                                "POST /user/create HTTP/1.1" + Const.CRLF +
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 59" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF +
                                 "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net"
                         )
                 )

--- a/src/test/java/webserver/http/message/ResponseMessageTest.java
+++ b/src/test/java/webserver/http/message/ResponseMessageTest.java
@@ -3,6 +3,7 @@ package webserver.http.message;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import webserver.Const;
 import webserver.http.Body;
 import webserver.http.header.Header;
 import webserver.http.header.ResponseHeader;
@@ -25,25 +26,25 @@ class ResponseMessageTest {
     static Stream<Arguments> getHeader() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                        "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                        "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                        System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                        "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                        "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                        Const.CRLF +
                         "Hello World",
                         ResponseHeader.from(
-                                "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator()
+                                "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF
                         )
                 ),
                 Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                        "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                        "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator(),
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                        "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                        "Content-Length: " + "Hello World".getBytes().length + Const.CRLF,
                         ResponseHeader.from(
-                                "HTTP/1.1 200 OK" + System.lineSeparator() +
-                                "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                                "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator()
+                                "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF
                         )
                 )
         );
@@ -61,31 +62,31 @@ class ResponseMessageTest {
     static Stream<Arguments> getBody() {
         return Stream.of(
                 Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                        "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                        "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                        System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                        "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                        "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                        Const.CRLF +
                         "Hello World",
                         Body.from("Hello World")
                 ), Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                        "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                        "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                        System.lineSeparator() +
-                        "Hello World" + System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                        "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                        "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                        Const.CRLF +
+                        "Hello World" + Const.CRLF +
                         "Bye World",
-                        Body.from("Hello World" + System.lineSeparator() +
+                        Body.from("Hello World" + Const.CRLF +
                                   "Bye World")
                 ), Arguments.of(
-                        "HTTP/1.1 200 OK" + System.lineSeparator() +
-                        "Content-Type: text/html;charset=utf-8" + System.lineSeparator() +
-                        "Content-Length: " + "Hello World".getBytes().length + System.lineSeparator() +
-                        System.lineSeparator() +
-                        "Hello World" + System.lineSeparator() +
-                        System.lineSeparator() +
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                        "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                        "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                        Const.CRLF +
+                        "Hello World" + Const.CRLF +
+                        Const.CRLF +
                         "Bye World",
-                        Body.from("Hello World" + System.lineSeparator() +
-                                  System.lineSeparator() +
+                        Body.from("Hello World" + Const.CRLF +
+                                  Const.CRLF +
                                   "Bye World")
                 )
         );


### PR DESCRIPTION
close #61 

CRLF를 전체 소스에서 공통적으로 사용하기때문에 Const 인터페이스를 만들어줬습니다.
상수로만 쓸 것이므로 클래스 대신 인터페이스로 선언했습니다.

html은 파일로 관리되므로 따로 신경써야 할 부분이 없어 일괄 변경 해줬습니다.
