### PR TITLE
StatusLine StartLine으로 이름 변경

### DIFF
--- a/src/main/java/webserver/http/statusline/RequestStatusLine.java
+++ b/src/main/java/webserver/http/statusline/RequestStatusLine.java
@@ -4,7 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 
-public class RequestStatusLine extends StatusLine {
+public class RequestStatusLine extends StartLine {
 
     private static final String METHOD_KEY = "method";
     private static final String PATH_KEY = "path";

--- a/src/main/java/webserver/http/statusline/RequestStatusLine.java
+++ b/src/main/java/webserver/http/statusline/RequestStatusLine.java
@@ -24,12 +24,12 @@ public class RequestStatusLine extends StartLine {
     }
 
     public String getMethod() {
-        return getStatusLineAttributeBy(METHOD_KEY);
+        return getAttributeBy(METHOD_KEY);
     }
 
     private URI getUri() {
         try {
-            return new URI(getStatusLineAttributeBy(PATH_KEY));
+            return new URI(getAttributeBy(PATH_KEY));
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Request의 Path가 올바르지 않음. path : " + getPath(), e);
         }

--- a/src/main/java/webserver/http/statusline/ResponseStatusLine.java
+++ b/src/main/java/webserver/http/statusline/ResponseStatusLine.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-public class ResponseStatusLine extends StatusLine {
+public class ResponseStatusLine extends StartLine {
     private static final String STATUS_CODE_KEY = "statusCode";
     private static final String STATUS_TEXT_KEY = "statusText";
 

--- a/src/main/java/webserver/http/statusline/ResponseStatusLine.java
+++ b/src/main/java/webserver/http/statusline/ResponseStatusLine.java
@@ -24,11 +24,11 @@ public class ResponseStatusLine extends StartLine {
     }
 
     public String getStatusCode() {
-        return getStatusLineAttributeBy(STATUS_CODE_KEY);
+        return getAttributeBy(STATUS_CODE_KEY);
     }
 
     public String getStatusText() {
-        return getStatusLineAttributeBy(STATUS_TEXT_KEY);
+        return getAttributeBy(STATUS_TEXT_KEY);
     }
 
     @Override

--- a/src/main/java/webserver/http/statusline/StartLine.java
+++ b/src/main/java/webserver/http/statusline/StartLine.java
@@ -4,12 +4,12 @@ import webserver.http.attribute.Attributes;
 
 import java.util.Map;
 
-public abstract class StatusLine {
+public abstract class StartLine {
     protected static final String PROTOCOL_VERSION_KEY = "protocolVersion";
 
     private Attributes statusLineAttributes;
 
-    public StatusLine(Map<String, String> statusLineAttributes) {
+    public StartLine(Map<String, String> statusLineAttributes) {
         this.statusLineAttributes = Attributes.from(statusLineAttributes);
     }
 

--- a/src/main/java/webserver/http/statusline/StartLine.java
+++ b/src/main/java/webserver/http/statusline/StartLine.java
@@ -7,17 +7,17 @@ import java.util.Map;
 public abstract class StartLine {
     protected static final String PROTOCOL_VERSION_KEY = "protocolVersion";
 
-    private Attributes statusLineAttributes;
+    private Attributes attributes;
 
-    public StartLine(Map<String, String> statusLineAttributes) {
-        this.statusLineAttributes = Attributes.from(statusLineAttributes);
+    public StartLine(Map<String, String> attributes) {
+        this.attributes = Attributes.from(attributes);
     }
 
     public String getProtocol() {
-        return statusLineAttributes.get(PROTOCOL_VERSION_KEY);
+        return attributes.get(PROTOCOL_VERSION_KEY);
     }
 
-    protected String getStatusLineAttributeBy(String key) {
-        return statusLineAttributes.get(key);
+    protected String getAttributeBy(String key) {
+        return attributes.get(key);
     }
 }


### PR DESCRIPTION
close #76 

이름 변경해주고, 내부에서 사용되는 변수 statusAttributes의 접두사가 불필요한 중복인 것 같아 빼줬습니다. 객체명에서 어떤 attributes인지 나타낸다고 생각했기 때문입니다.