### PR TITLE
header의 start line 없애기

### DIFF
--- a/src/main/java/util/HttpRequestUtils.java
+++ b/src/main/java/util/HttpRequestUtils.java
@@ -2,6 +2,7 @@ package util;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import webserver.Const;
 
 import java.util.Arrays;
 import java.util.List;
@@ -57,6 +58,11 @@ public class HttpRequestUtils {
     public static List<String> parseStartLine(String statusLine) {
         return Arrays.stream(statusLine.split(" "))
                 .collect(Collectors.toList());
+    }
+
+    public static List<String> extractStartLineFrom(String headerText) {
+        String[] splittedHeaderTexts = headerText.split(Const.CRLF);
+        return parseStartLine(splittedHeaderTexts[0]);
     }
 
     public static class Pair {

--- a/src/main/java/webserver/http/Response.java
+++ b/src/main/java/webserver/http/Response.java
@@ -1,10 +1,12 @@
 package webserver.http;
 
+import webserver.Const;
 import webserver.http.message.ResponseMessage;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 
 public class Response {
     private ResponseMessage responseMessage;
@@ -20,10 +22,11 @@ public class Response {
     public void write(OutputStream outputStream) throws IOException {
         DataOutputStream dos = new DataOutputStream(outputStream);
         // TODO: message.getBytes() 와 같이 수정 가능
-        // byte[] status = responseMessage.get
+        byte[] status = (responseMessage.getStatusLine().toString() + Const.CRLF).getBytes(StandardCharsets.UTF_8);
         byte[] header = responseMessage.getHeader().getBytes();
         byte[] body = responseMessage.getBody().getBytes();
 
+        dos.write(status);
         dos.write(header);
         dos.write(body);
         dos.flush();

--- a/src/main/java/webserver/http/Response.java
+++ b/src/main/java/webserver/http/Response.java
@@ -19,6 +19,8 @@ public class Response {
 
     public void write(OutputStream outputStream) throws IOException {
         DataOutputStream dos = new DataOutputStream(outputStream);
+        // TODO: message.getBytes() 와 같이 수정 가능
+        // byte[] status = responseMessage.get
         byte[] header = responseMessage.getHeader().getBytes();
         byte[] body = responseMessage.getBody().getBytes();
 

--- a/src/main/java/webserver/http/header/Header.java
+++ b/src/main/java/webserver/http/header/Header.java
@@ -14,7 +14,7 @@ public abstract class Header {
         this.attributes = attributes;
     }
 
-    protected static List<String> parseStartLine(String headerText) {
+    public static List<String> parseStartLine(String headerText) {
         String[] splittedHeaderTexts = headerText.split(Const.CRLF);
         return HttpRequestUtils.parseStartLine(splittedHeaderTexts[0]);
     }

--- a/src/main/java/webserver/http/header/Header.java
+++ b/src/main/java/webserver/http/header/Header.java
@@ -26,16 +26,10 @@ public abstract class Header {
     public byte[] getBytes() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(getStartLine()).append(Const.CRLF);
-
         String attributesString = attributes.toHeaderText();
-
         sb.append(attributesString + (!attributesString.isEmpty() ? Const.CRLF : ""));
-
         sb.append(Const.CRLF);
 
         return sb.toString().getBytes(StandardCharsets.UTF_8);
     }
-
-    protected abstract String getStartLine();
 }

--- a/src/main/java/webserver/http/header/Header.java
+++ b/src/main/java/webserver/http/header/Header.java
@@ -1,22 +1,15 @@
 package webserver.http.header;
 
-import util.HttpRequestUtils;
 import webserver.Const;
 import webserver.http.attribute.Attributes;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 public abstract class Header {
     private Attributes attributes;
 
     protected Header(Attributes attributes) {
         this.attributes = attributes;
-    }
-
-    public static List<String> parseStartLine(String headerText) {
-        String[] splittedHeaderTexts = headerText.split(Const.CRLF);
-        return HttpRequestUtils.parseStartLine(splittedHeaderTexts[0]);
     }
 
     public Attributes getAttributes() {

--- a/src/main/java/webserver/http/header/RequestHeader.java
+++ b/src/main/java/webserver/http/header/RequestHeader.java
@@ -1,40 +1,18 @@
 package webserver.http.header;
 
 import webserver.http.attribute.Attributes;
-import webserver.http.startline.RequestLine;
-
-import java.util.List;
 
 public class RequestHeader extends Header {
-    private RequestLine requestLine;
 
-    protected RequestHeader(RequestLine requestLine, Attributes attributes) {
+    protected RequestHeader(Attributes attributes) {
         super(attributes);
-        this.requestLine = requestLine;
     }
 
-    public static RequestHeader of(List<String> statusLine, Attributes attributes) {
-        return new RequestHeader(RequestLine.from(statusLine), attributes);
+    public static RequestHeader of(Attributes attributes) {
+        return new RequestHeader(attributes);
     }
 
     public static RequestHeader from(String headerText) {
-        return RequestHeader.of(parseStartLine(headerText), Attributes.from(headerText));
-    }
-
-    public String getPath() {
-        return requestLine.getPath();
-    }
-
-    public String getMethod() {
-        return requestLine.getMethod();
-    }
-
-    @Override
-    protected String getStartLine() {
-        return requestLine.toString();
-    }
-
-    public String getQueryString() {
-        return requestLine.getQueryString();
+        return RequestHeader.of(Attributes.from(headerText));
     }
 }

--- a/src/main/java/webserver/http/header/ResponseHeader.java
+++ b/src/main/java/webserver/http/header/ResponseHeader.java
@@ -2,30 +2,21 @@ package webserver.http.header;
 
 import webserver.Const;
 import webserver.http.attribute.Attributes;
-import webserver.http.startline.StatusLine;
 
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 public class ResponseHeader extends Header {
 
-    private StatusLine statusLine;
-
-    protected ResponseHeader(StatusLine statusLine, Attributes attributes) {
+    protected ResponseHeader(Attributes attributes) {
         super(attributes);
-        this.statusLine = statusLine;
     }
 
-    public static ResponseHeader of(List<String> statusLine, Attributes attributes) {
-        return new ResponseHeader(StatusLine.from(statusLine), attributes);
+    public static ResponseHeader from(Attributes attributes) {
+        return new ResponseHeader(attributes);
     }
 
     public static ResponseHeader from(String headerText) {
-        return ResponseHeader.of(parseStartLine(headerText), Attributes.from(headerText));
-    }
-
-    protected String getStartLine() {
-        return statusLine.toString();
+        return ResponseHeader.from(Attributes.from(headerText));
     }
 
     public byte[] getBytes() {

--- a/src/main/java/webserver/http/header/ResponseHeader.java
+++ b/src/main/java/webserver/http/header/ResponseHeader.java
@@ -1,8 +1,10 @@
 package webserver.http.header;
 
+import webserver.Const;
 import webserver.http.attribute.Attributes;
 import webserver.http.startline.StatusLine;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class ResponseHeader extends Header {
@@ -22,8 +24,21 @@ public class ResponseHeader extends Header {
         return ResponseHeader.of(parseStartLine(headerText), Attributes.from(headerText));
     }
 
-    @Override
     protected String getStartLine() {
         return statusLine.toString();
+    }
+
+    public byte[] getBytes() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(getStartLine()).append(Const.CRLF);
+
+        String attributesString = getAttributes().toHeaderText();
+
+        sb.append(attributesString + (!attributesString.isEmpty() ? Const.CRLF : ""));
+
+        sb.append(Const.CRLF);
+
+        return sb.toString().getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/webserver/http/header/ResponseHeader.java
+++ b/src/main/java/webserver/http/header/ResponseHeader.java
@@ -31,8 +31,6 @@ public class ResponseHeader extends Header {
     public byte[] getBytes() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(getStartLine()).append(Const.CRLF);
-
         String attributesString = getAttributes().toHeaderText();
 
         sb.append(attributesString + (!attributesString.isEmpty() ? Const.CRLF : ""));

--- a/src/main/java/webserver/http/message/GetMessage.java
+++ b/src/main/java/webserver/http/message/GetMessage.java
@@ -2,18 +2,17 @@ package webserver.http.message;
 
 import util.HttpRequestUtils;
 import webserver.http.header.RequestHeader;
+import webserver.http.startline.RequestLine;
 
 import java.util.Map;
 
 public class GetMessage implements RequestMessage {
+    private RequestLine requestLine;
     private RequestHeader header;
 
-    public GetMessage(RequestHeader header) {
+    public GetMessage(RequestLine requestLine, RequestHeader header) {
+        this.requestLine = requestLine;
         this.header = header;
-    }
-
-    public static GetMessage from(String getMessage) {
-        return new GetMessage(RequestHeader.from(getMessage));
     }
 
     @Override
@@ -23,11 +22,24 @@ public class GetMessage implements RequestMessage {
 
     @Override
     public String getMethod() {
-        return header.getMethod();
+        return requestLine.getMethod();
     }
 
     @Override
     public Map<String, String> getParameters() {
-        return HttpRequestUtils.parseQueryString(header.getQueryString());
+        return HttpRequestUtils.parseQueryString(getQueryString());
+    }
+
+    @Override
+    public String getPath() {
+        return requestLine.getPath();
+    }
+
+    public RequestLine getStartLine() {
+        return requestLine;
+    }
+
+    public String getQueryString() {
+        return requestLine.getQueryString();
     }
 }

--- a/src/main/java/webserver/http/message/GetMessage.java
+++ b/src/main/java/webserver/http/message/GetMessage.java
@@ -35,7 +35,8 @@ public class GetMessage implements RequestMessage {
         return requestLine.getPath();
     }
 
-    public RequestLine getStartLine() {
+    @Override
+    public RequestLine getRequestLine() {
         return requestLine;
     }
 

--- a/src/main/java/webserver/http/message/PostMessage.java
+++ b/src/main/java/webserver/http/message/PostMessage.java
@@ -50,4 +50,9 @@ public class PostMessage implements RequestMessage {
             throw new IllegalStateException("인코딩 오류", e);
         }
     }
+
+    @Override
+    public String getPath() {
+        return header.getPath();
+    }
 }

--- a/src/main/java/webserver/http/message/PostMessage.java
+++ b/src/main/java/webserver/http/message/PostMessage.java
@@ -49,4 +49,9 @@ public class PostMessage implements RequestMessage {
     public String getPath() {
         return requestLine.getPath();
     }
+
+    @Override
+    public RequestLine getRequestLine() {
+        return requestLine;
+    }
 }

--- a/src/main/java/webserver/http/message/PostMessage.java
+++ b/src/main/java/webserver/http/message/PostMessage.java
@@ -1,9 +1,9 @@
 package webserver.http.message;
 
 import util.HttpRequestUtils;
-import webserver.Const;
 import webserver.http.Body;
 import webserver.http.header.RequestHeader;
+import webserver.http.startline.RequestLine;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -11,20 +11,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 public class PostMessage implements RequestMessage {
+    private RequestLine requestLine;
     private RequestHeader header;
     private Body body;
 
-    public PostMessage(RequestHeader header, Body body) {
+    public PostMessage(RequestLine requestLine, RequestHeader header, Body body) {
+        this.requestLine = requestLine;
         this.header = header;
         this.body = body;
-    }
-
-    public static PostMessage from(String postMessage) {
-        String[] splittedPostMessage = postMessage.split(Const.CRLF + Const.CRLF);
-
-        Body body = Body.from(splittedPostMessage.length != 1 ? splittedPostMessage[1] : "");
-
-        return new PostMessage(RequestHeader.from(splittedPostMessage[0]), body);
     }
 
     @Override
@@ -38,7 +32,7 @@ public class PostMessage implements RequestMessage {
 
     @Override
     public String getMethod() {
-        return header.getMethod();
+        return requestLine.getMethod();
     }
 
     @Override
@@ -53,6 +47,6 @@ public class PostMessage implements RequestMessage {
 
     @Override
     public String getPath() {
-        return header.getPath();
+        return requestLine.getPath();
     }
 }

--- a/src/main/java/webserver/http/message/RequestMessage.java
+++ b/src/main/java/webserver/http/message/RequestMessage.java
@@ -15,8 +15,9 @@ public interface RequestMessage {
         RequestLine requestLine = RequestLine.from(parseStartLine(splitMessage[0]));
         RequestHeader header = RequestHeader.from(splitMessage[0]);
 
-        if (header.getMethod().equalsIgnoreCase("post")) {
-            return PostMessage.from(message);
+        if (requestLine.getMethod().equalsIgnoreCase("post")) {
+            Body body = Body.from(splitMessage[1]);
+            return new PostMessage(requestLine, header, body);
         }
 
         return new GetMessage(requestLine, header);

--- a/src/main/java/webserver/http/message/RequestMessage.java
+++ b/src/main/java/webserver/http/message/RequestMessage.java
@@ -7,12 +7,13 @@ import webserver.http.startline.RequestLine;
 
 import java.util.Map;
 
-import static webserver.http.header.Header.parseStartLine;
+import static util.HttpRequestUtils.extractStartLineFrom;
+
 
 public interface RequestMessage {
     static RequestMessage from(String message) {
         String[] splitMessage = message.split(Const.CRLF + Const.CRLF);
-        RequestLine requestLine = RequestLine.from(parseStartLine(splitMessage[0]));
+        RequestLine requestLine = RequestLine.from(extractStartLineFrom(splitMessage[0]));
         RequestHeader header = RequestHeader.from(splitMessage[0]);
 
         if (requestLine.getMethod().equalsIgnoreCase("post")) {

--- a/src/main/java/webserver/http/message/RequestMessage.java
+++ b/src/main/java/webserver/http/message/RequestMessage.java
@@ -30,4 +30,6 @@ public interface RequestMessage {
     Map<String, String> getParameters();
 
     String getPath();
+
+    RequestLine getRequestLine();
 }

--- a/src/main/java/webserver/http/message/RequestMessage.java
+++ b/src/main/java/webserver/http/message/RequestMessage.java
@@ -1,19 +1,25 @@
 package webserver.http.message;
 
 import webserver.Const;
+import webserver.http.Body;
 import webserver.http.header.RequestHeader;
+import webserver.http.startline.RequestLine;
 
 import java.util.Map;
 
+import static webserver.http.header.Header.parseStartLine;
+
 public interface RequestMessage {
     static RequestMessage from(String message) {
-        RequestHeader header = RequestHeader.from(message.split(Const.CRLF)[0]);
+        String[] splitMessage = message.split(Const.CRLF + Const.CRLF);
+        RequestLine requestLine = RequestLine.from(parseStartLine(splitMessage[0]));
+        RequestHeader header = RequestHeader.from(splitMessage[0]);
 
         if (header.getMethod().equalsIgnoreCase("post")) {
             return PostMessage.from(message);
         }
 
-        return GetMessage.from(message);
+        return new GetMessage(requestLine, header);
     }
 
     RequestHeader getHeader();
@@ -22,7 +28,5 @@ public interface RequestMessage {
 
     Map<String, String> getParameters();
 
-    default String getPath() {
-        return getHeader().getPath();
-    }
+    String getPath();
 }

--- a/src/main/java/webserver/http/message/ResponseMessage.java
+++ b/src/main/java/webserver/http/message/ResponseMessage.java
@@ -7,7 +7,7 @@ import webserver.http.startline.StatusLine;
 
 import java.util.StringJoiner;
 
-import static webserver.http.header.Header.parseStartLine;
+import static util.HttpRequestUtils.extractStartLineFrom;
 
 public class ResponseMessage {
 
@@ -23,7 +23,7 @@ public class ResponseMessage {
 
     public static ResponseMessage from(String responseMessage) {
         String[] splittedResponseMessage = responseMessage.split(Const.CRLF + Const.CRLF);
-        StatusLine statusLine = StatusLine.from(parseStartLine(splittedResponseMessage[0]));
+        StatusLine statusLine = StatusLine.from(extractStartLineFrom(splittedResponseMessage[0]));
 
         StringJoiner body = new StringJoiner(Const.CRLF + Const.CRLF);
 

--- a/src/main/java/webserver/http/message/ResponseMessage.java
+++ b/src/main/java/webserver/http/message/ResponseMessage.java
@@ -3,20 +3,27 @@ package webserver.http.message;
 import webserver.Const;
 import webserver.http.Body;
 import webserver.http.header.ResponseHeader;
+import webserver.http.startline.StatusLine;
 
 import java.util.StringJoiner;
 
+import static webserver.http.header.Header.parseStartLine;
+
 public class ResponseMessage {
+
+    private StatusLine statusLine;
     private ResponseHeader header;
     private Body body;
 
-    public ResponseMessage(ResponseHeader header, Body body) {
+    public ResponseMessage(StatusLine statusLine, ResponseHeader header, Body body) {
+        this.statusLine = statusLine;
         this.header = header;
         this.body = body;
     }
 
     public static ResponseMessage from(String responseMessage) {
         String[] splittedResponseMessage = responseMessage.split(Const.CRLF + Const.CRLF);
+        StatusLine statusLine = StatusLine.from(parseStartLine(splittedResponseMessage[0]));
 
         StringJoiner body = new StringJoiner(Const.CRLF + Const.CRLF);
 
@@ -24,7 +31,11 @@ public class ResponseMessage {
             body.add(splittedResponseMessage[i]);
         }
 
-        return new ResponseMessage(ResponseHeader.from(splittedResponseMessage[0]), Body.from(body.toString()));
+        return new ResponseMessage(statusLine, ResponseHeader.from(splittedResponseMessage[0]), Body.from(body.toString()));
+    }
+
+    public StatusLine getStatusLine() {
+        return statusLine;
     }
 
     public ResponseHeader getHeader() {

--- a/src/test/java/util/HttpRequestUtilsTest.java
+++ b/src/test/java/util/HttpRequestUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import util.HttpRequestUtils.Pair;
+import webserver.Const;
 
 import java.util.Arrays;
 import java.util.List;
@@ -145,6 +146,27 @@ class HttpRequestUtilsTest {
                 Arguments.of(
                         "GET /user/create HTTP/1.1",
                         Arrays.asList("GET", "/user/create", "HTTP/1.1")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("extractStartLineFrom")
+    void extractStartLineFrom(String headerText, List<String> expectedParsedStatusLine) {
+        assertThat(HttpRequestUtils.extractStartLineFrom(headerText)).isEqualTo(expectedParsedStatusLine);
+    }
+
+    static Stream<Arguments> extractStartLineFrom() {
+        return Stream.of(
+                Arguments.of(
+                        "GET /user/create HTTP/1.1",
+                        Arrays.asList("GET", "/user/create", "HTTP/1.1")
+                ),
+                Arguments.of(
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World" .getBytes().length,
+                        Arrays.asList("HTTP/1.1", "200", "OK")
                 )
         );
     }

--- a/src/test/java/webserver/http/RequestTest.java
+++ b/src/test/java/webserver/http/RequestTest.java
@@ -10,6 +10,7 @@ import webserver.http.header.RequestHeader;
 import webserver.http.message.GetMessage;
 import webserver.http.message.PostMessage;
 import webserver.http.message.RequestMessage;
+import webserver.http.startline.RequestLine;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,35 +33,44 @@ class RequestTest {
         return Stream.of(
                 Arguments.of(
                         "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
-                        "Host: localhost:8080" + Const.CRLF +
-                        "Connection: keep-alive" + Const.CRLF +
-                        "Content-Length: 59" + Const.CRLF +
-                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                        "Accept: */*" + Const.CRLF +
-                        "" + Const.CRLF,
-                        new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                        "HTTP/1.1"
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 59" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF,
+                        new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )
                 ), Arguments.of(
                         "POST /user/create HTTP/1.1" + Const.CRLF +
-                        "Host: localhost:8080" + Const.CRLF +
-                        "Connection: keep-alive" + Const.CRLF +
-                        "Content-Length: 59" + Const.CRLF +
-                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                        "Accept: */*" + Const.CRLF +
-                        "" + Const.CRLF +
-                        "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                "Host: localhost:8080" + Const.CRLF +
+                                "Connection: keep-alive" + Const.CRLF +
+                                "Content-Length: 59" + Const.CRLF +
+                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                "Accept: */*" + Const.CRLF +
+                                "" + Const.CRLF +
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                         new PostMessage(
                                 RequestHeader.of(
                                         Arrays.asList(
@@ -88,44 +98,62 @@ class RequestTest {
         String actualPath = new Request(getMessage).getPath();
 
         assertThat(actualPath).as(desc)
-                              .isEqualTo(expectedPath);
+                .isEqualTo(expectedPath);
     }
 
     static Stream<Arguments> getPath() {
         return Stream.of(
                 Arguments.of(
                         "쿼리스트링이 없는 GET 메세지",
-                        new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create",
-                                        "HTTP/1.1"
+                        new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        )),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        ),
                         "/user/create"
                 ), Arguments.of(
                         "쿼리스트링이 포함된 GET 메세지 path를 출력할때도 쿼리스트링이 포함되지 않아야 함",
-                        new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                        "HTTP/1.1"
+                        new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        )),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        ),
                         "/user/create"
                 )
         );
@@ -136,147 +164,219 @@ class RequestTest {
     @MethodSource("getPathExtension")
     void getPathExtension(String desc, Request request, String expectedExtension) {
         Assertions.assertThat(request.getPathExtension())
-                  .as("status line에서 path의 확장자 가져오기 : %s", desc)
-                  .isEqualTo(expectedExtension);
+                .as("status line에서 path의 확장자 가져오기 : %s", desc)
+                .isEqualTo(expectedExtension);
     }
 
     static Stream<Arguments> getPathExtension() {
         return Stream.of(
                 Arguments.of(
                         "확장자가 있는 path",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create.html",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         "html"
                 ), Arguments.of(
                         "확장자가 있는 path /로 끝남",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create.html/",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html/",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html/",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         "html"
                 ), Arguments.of(
                         "확장자와 쿼리스트링이 함께 있는 path",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         "html"
                 ), Arguments.of(
                         "확장자와 쿼리스트링이 함께 있는 path /로 끝남",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net/",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net/",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net/",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         "html"
                 ), Arguments.of(
                         "확장자가 없는 path",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         ""
                 ), Arguments.of(
                         "root만 있는 path",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         ""
                 ), Arguments.of(
                         "비어 있는 path",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         ""
                 ), Arguments.of(
                         "확장자가 없는데 쿼리스트링이 있는 path",
-                        new Request(new GetMessage(RequestHeader.of(
-                                Arrays.asList(
-                                        "GET",
-                                        "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                        "HTTP/1.1"
+                        new Request(new GetMessage(
+                                RequestLine.from(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                                "HTTP/1.1"
+                                        )
                                 ),
-                                Attributes.from(new HashMap() {{
-                                    put("Host", "localhost:8080");
-                                    put("Connection", "keep-alive");
-                                    put("Content-Length", "59");
-                                    put("Content-Type", "application/x-www-form-urlencoded");
-                                    put("Accept", "*/*");
-                                }})
-                        ))),
+                                RequestHeader.of(
+                                        Arrays.asList(
+                                                "GET",
+                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                                "HTTP/1.1"
+                                        ),
+                                        Attributes.from(new HashMap() {{
+                                            put("Host", "localhost:8080");
+                                            put("Connection", "keep-alive");
+                                            put("Content-Length", "59");
+                                            put("Content-Type", "application/x-www-form-urlencoded");
+                                            put("Accept", "*/*");
+                                        }})
+                                )
+                        )),
                         ""
                 )
         );

--- a/src/test/java/webserver/http/RequestTest.java
+++ b/src/test/java/webserver/http/RequestTest.java
@@ -72,6 +72,11 @@ class RequestTest {
                                 "" + Const.CRLF +
                                 "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
                         new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
                                 RequestHeader.of(
                                         Arrays.asList(
                                                 "POST",

--- a/src/test/java/webserver/http/RequestTest.java
+++ b/src/test/java/webserver/http/RequestTest.java
@@ -48,11 +48,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -78,11 +73,6 @@ class RequestTest {
                                         "HTTP/1.1"
                                 )),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "POST",
-                                                "/user/create",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -119,11 +109,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -145,11 +130,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -186,11 +166,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create.html",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -212,11 +187,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create.html/",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -238,11 +208,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -264,11 +229,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create.html?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net/",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -290,11 +250,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -316,11 +271,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -342,11 +292,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");
@@ -368,11 +313,6 @@ class RequestTest {
                                         )
                                 ),
                                 RequestHeader.of(
-                                        Arrays.asList(
-                                                "GET",
-                                                "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                                                "HTTP/1.1"
-                                        ),
                                         Attributes.from(new HashMap() {{
                                             put("Host", "localhost:8080");
                                             put("Connection", "keep-alive");

--- a/src/test/java/webserver/http/header/RequestHeaderTest.java
+++ b/src/test/java/webserver/http/header/RequestHeaderTest.java
@@ -68,87 +68,6 @@ class RequestHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getMethod")
-    void getMethod(String headerText, String expectedMethod) {
-        assertThat(RequestHeader.from(headerText).getMethod())
-                .isEqualTo(expectedMethod);
-    }
-
-    static Stream<Arguments> getMethod() {
-        return Stream.of(
-                Arguments.of(
-                        "GET / HTTP/1.1" + Const.CRLF +
-                                "Host: localhost:8080" + Const.CRLF +
-                                "Connection: keep-alive" + Const.CRLF +
-                                "Cache-Control: max-age=0" + Const.CRLF +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
-                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
-                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
-                                "Sec-Fetch-Site: none" + Const.CRLF +
-                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
-                                "Sec-Fetch-User: ?1" + Const.CRLF +
-                                "Sec-Fetch-Dest: document" + Const.CRLF +
-                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
-                                Const.CRLF,
-                        "GET"
-                ), Arguments.of(
-                        "POST /user/create HTTP/1.1" + Const.CRLF +
-                                "Host: localhost:8080" + Const.CRLF +
-                                "Connection: keep-alive" + Const.CRLF +
-                                "Content-Length: 59" + Const.CRLF +
-                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                                "Accept: */*" + Const.CRLF +
-                                "" + Const.CRLF +
-                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                        "POST"
-                )
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("getRequestLineAttributes")
-    void getRequestLineAttributes(String headerText, RequestLine expectedRequestLine) {
-        assertThat(RequestHeader.from(headerText))
-                .extracting("requestLine")
-                .usingRecursiveFieldByFieldElementComparator()
-                .contains(expectedRequestLine);
-    }
-
-    static Stream<Arguments> getRequestLineAttributes() {
-        return Stream.of(
-                Arguments.of("GET / HTTP/1.1" + Const.CRLF +
-                                "Host: localhost:8080" + Const.CRLF +
-                                "Connection: keep-alive" + Const.CRLF +
-                                "Cache-Control: max-age=0" + Const.CRLF +
-                                "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
-                                "sec-ch-ua-mobile: ?0" + Const.CRLF +
-                                "Upgrade-Insecure-Requests: 1" + Const.CRLF +
-                                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36" + Const.CRLF +
-                                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9" + Const.CRLF +
-                                "Sec-Fetch-Site: none" + Const.CRLF +
-                                "Sec-Fetch-Mode: navigate" + Const.CRLF +
-                                "Sec-Fetch-User: ?1" + Const.CRLF +
-                                "Sec-Fetch-Dest: document" + Const.CRLF +
-                                "Accept-Encoding: gzip, deflate, br" + Const.CRLF +
-                                "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
-                                "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
-                                Const.CRLF,
-                        new RequestLine(
-                                new HashMap<String, String>() {{
-                                    put("method", "GET");
-                                    put("path", "/");
-                                    put("protocolVersion", "HTTP/1.1");
-                                }}
-                        )
-                )
-        );
-    }
-
-    @ParameterizedTest
     @MethodSource("getBytes")
     void getBytes(String headerText, byte[] expectedHeaderByte) {
         byte[] headerByte = RequestHeader.from(headerText).getBytes();
@@ -180,8 +99,7 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
                                 Const.CRLF,
-                        ("GET / HTTP/1.1" + Const.CRLF +
-                                "Host: localhost:8080" + Const.CRLF +
+                        ("Host: localhost:8080" + Const.CRLF +
                                 "Connection: keep-alive" + Const.CRLF +
                                 "Cache-Control: max-age=0" + Const.CRLF +
                                 "sec-ch-ua: \"Google Chrome\";v=\"89\", \"Chromium\";v=\"89\", \";Not A Brand\";v=\"99\"" + Const.CRLF +
@@ -197,44 +115,6 @@ class RequestHeaderTest {
                                 "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7" + Const.CRLF +
                                 "Cookie: Idea-1c77831=5ced54c8-cabd-4355-ae5a-97b17f9d7443" + Const.CRLF +
                                 Const.CRLF).getBytes(StandardCharsets.UTF_8)
-                )
-        );
-    }
-
-    @ParameterizedTest
-    @MethodSource("getPath")
-    void getPath(String desc, RequestLine statusLine, String expectedPath) {
-        RequestHeader requestHeader = new RequestHeader(statusLine, Attributes.from(new HashMap<>()));
-
-        String actualPath = requestHeader.getPath();
-
-        assertThat(actualPath).as("리퀘스트 헤더에서 path 가져오기 : %s", desc)
-                .isEqualTo(expectedPath);
-    }
-
-    static Stream<Arguments> getPath() {
-        return Stream.of(
-                Arguments.of(
-                        "쿼리스트링이 없는 GET 메세지",
-                        new RequestLine(
-                                new HashMap() {{
-                                    put("path", "/user/create");
-                                    put("method", "GET");
-                                    put("protocolVersion", "HTTP/1.1");
-                                }}
-                        ),
-                        "/user/create"
-                ),
-                Arguments.of(
-                        "쿼리스트링이 포함된 GET 메세지 path를 출력할때도 쿼리스트링이 포함되지 않아야 함",
-                        new RequestLine(
-                                new HashMap() {{
-                                    put("path", "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net");
-                                    put("method", "GET");
-                                    put("protocolVersion", "HTTP/1.1");
-                                }}
-                        ),
-                        "/user/create"
                 )
         );
     }

--- a/src/test/java/webserver/http/header/ResponseHeaderTest.java
+++ b/src/test/java/webserver/http/header/ResponseHeaderTest.java
@@ -41,33 +41,6 @@ class ResponseHeaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("getStatusLineAttributes")
-    void getStatusLineAttributes(String headerText, StatusLine expectedStatusLine) {
-        assertThat(ResponseHeader.from(headerText))
-                .extracting("statusLine")
-                .usingRecursiveFieldByFieldElementComparator()
-                .contains(expectedStatusLine);
-    }
-
-    static Stream<Arguments> getStatusLineAttributes() {
-        return Stream.of(
-                Arguments.of(
-                        "HTTP/1.1 200 OK" + Const.CRLF +
-                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
-                                "Content-Length: " + "Hello World" .getBytes().length + Const.CRLF +
-                                Const.CRLF,
-                        new StatusLine(
-                                new HashMap() {{
-                                    put("protocolVersion", "HTTP/1.1");
-                                    put("statusText", "OK");
-                                    put("statusCode", "200");
-                                }}
-                        )
-                )
-        );
-    }
-
-    @ParameterizedTest
     @MethodSource("getBytes")
     void getBytes(String headerText, byte[] expectedHeaderByte) {
         byte[] headerByte = ResponseHeader.from(headerText).getBytes();

--- a/src/test/java/webserver/http/header/ResponseHeaderTest.java
+++ b/src/test/java/webserver/http/header/ResponseHeaderTest.java
@@ -28,12 +28,12 @@ class ResponseHeaderTest {
                 Arguments.of(
                         "HTTP/1.1 200 OK" + Const.CRLF +
                                 "Content-Type: text/html;charset=utf-8" + Const.CRLF +
-                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                "Content-Length: " + "Hello World" .getBytes().length + Const.CRLF +
                                 Const.CRLF,
                         Attributes.from(
                                 new LinkedHashMap<String, String>() {{
                                     put("Content-Type", "text/html;charset=utf-8");
-                                    put("Content-Length", String.valueOf("Hello World".getBytes().length));
+                                    put("Content-Length", String.valueOf("Hello World" .getBytes().length));
                                 }}
                         )
                 )
@@ -54,7 +54,7 @@ class ResponseHeaderTest {
                 Arguments.of(
                         "HTTP/1.1 200 OK" + Const.CRLF +
                                 "Content-Type: text/html;charset=utf-8" + Const.CRLF +
-                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                "Content-Length: " + "Hello World" .getBytes().length + Const.CRLF +
                                 Const.CRLF,
                         new StatusLine(
                                 new HashMap() {{
@@ -83,11 +83,10 @@ class ResponseHeaderTest {
                 Arguments.of(
                         "HTTP/1.1 200 OK" + Const.CRLF +
                                 "Content-Type: text/html;charset=utf-8" + Const.CRLF +
-                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                                "Content-Length: " + "Hello World" .getBytes().length + Const.CRLF +
                                 Const.CRLF,
-                        ("HTTP/1.1 200 OK" + Const.CRLF +
-                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
-                                "Content-Length: " + "Hello World".getBytes().length + Const.CRLF +
+                        ("Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World" .getBytes().length + Const.CRLF +
                                 Const.CRLF).getBytes(StandardCharsets.UTF_8)
                 )
         );

--- a/src/test/java/webserver/http/message/GetMessageTest.java
+++ b/src/test/java/webserver/http/message/GetMessageTest.java
@@ -1,5 +1,6 @@
 package webserver.http.message;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -155,6 +156,43 @@ class GetMessageTest {
                                 )
                         ),
                         "/user/create"
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRequestLine")
+    void getRequestLine(GetMessage getMessage, RequestLine expectedRequestLine) {
+        Assertions.assertThat(getMessage)
+                .extracting("requestLine")
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(expectedRequestLine);
+    }
+
+    static Stream<Arguments> getRequestLine() {
+        return Stream.of(
+                Arguments.of(
+                        new GetMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "GET",
+                                        "/",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "GET /user/create HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Content-Length: 59" + Const.CRLF +
+                                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF)
+                        ),
+                        new RequestLine(
+                                new HashMap<String, String>() {{
+                                    put("method", "GET");
+                                    put("path", "/");
+                                    put("protocolVersion", "HTTP/1.1");
+                                }}
+                        )
                 )
         );
     }

--- a/src/test/java/webserver/http/message/GetMessageTest.java
+++ b/src/test/java/webserver/http/message/GetMessageTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import webserver.Const;
 import webserver.http.header.RequestHeader;
+import webserver.http.startline.RequestLine;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -15,9 +17,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 class GetMessageTest {
     @ParameterizedTest
     @MethodSource("getHeader")
-    void getHeader(String messageText, RequestHeader expectedRequestHeader) {
-        GetMessage getMessage = GetMessage.from(messageText);
-
+    void getHeader(GetMessage getMessage, RequestHeader expectedRequestHeader) {
         assertThat(getMessage)
                 .extracting("header")
                 .usingRecursiveFieldByFieldElementComparator()
@@ -26,23 +26,26 @@ class GetMessageTest {
 
     static Stream<Arguments> getHeader() {
         return Stream.of(
-                //TODO getMessage인데 POST가  성공하는 테스트케이스로 들어가 있음!
                 Arguments.of(
-                        "GET /user/create HTTP/1.1" + Const.CRLF +
-                        "Host: localhost:8080" + Const.CRLF +
-                        "Connection: keep-alive" + Const.CRLF +
-                        "Content-Length: 59" + Const.CRLF +
-                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                        "Accept: */*" + Const.CRLF +
-                        "" + Const.CRLF,
+                        new GetMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "GET",
+                                        "/users",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "GET /users HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF
+                                )
+                        ),
                         RequestHeader.from(
-                                "GET /user/create HTTP/1.1" + Const.CRLF +
-                                "Host: localhost:8080" + Const.CRLF +
-                                "Connection: keep-alive" + Const.CRLF +
-                                "Content-Length: 59" + Const.CRLF +
-                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                                "Accept: */*" + Const.CRLF +
-                                "" + Const.CRLF
+                                "GET /users HTTP/1.1" + Const.CRLF +
+                                        "Host: localhost:8080" + Const.CRLF +
+                                        "Connection: keep-alive" + Const.CRLF +
+                                        "Accept: */*" + Const.CRLF +
+                                        "" + Const.CRLF
                         )
                 )
         );
@@ -50,29 +53,34 @@ class GetMessageTest {
 
     @ParameterizedTest
     @MethodSource("getMethod")
-    void getMethod(String messageText, String expectedRequestMethod) {
-        GetMessage getMessage = GetMessage.from(messageText);
+    void getMethod(GetMessage getMessage, String expectedRequestMethod) {
         assertThat(getMessage.getMethod()).isEqualTo(expectedRequestMethod);
     }
 
     static Stream<Arguments> getMethod() {
         return Stream.of(
-                Arguments.of("GET /user/create HTTP/1.1" + Const.CRLF +
-                             "Host: localhost:8080" + Const.CRLF +
-                             "Connection: keep-alive" + Const.CRLF +
-                             "Content-Length: 59" + Const.CRLF +
-                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                             "Accept: */*" + Const.CRLF +
-                             "" + Const.CRLF,
-                             "GET"
+                Arguments.of(
+                        new GetMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "GET",
+                                        "/users",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "GET /users HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF
+                                )
+                        ),
+                        "GET"
                 )
         );
     }
 
     @ParameterizedTest
     @MethodSource("getParameters")
-    void getParameters(String messageText, Map<String, String> expectedParameters) {
-        GetMessage getMessage = GetMessage.from(messageText);
+    void getParameters(GetMessage getMessage, Map<String, String> expectedParameters) {
         assertThat(getMessage.getParameters())
                 .isEqualTo(expectedParameters);
     }
@@ -80,19 +88,73 @@ class GetMessageTest {
     static Stream<Arguments> getParameters() {
         return Stream.of(
                 Arguments.of(
-                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
-                        "Host: localhost:8080" + Const.CRLF +
-                        "Connection: keep-alive" + Const.CRLF +
-                        "Content-Length: 59" + Const.CRLF +
-                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                        "Accept: */*" + Const.CRLF +
-                        "" + Const.CRLF,
+                        new GetMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "GET",
+                                        "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF
+                                )
+                        ),
                         new HashMap<String, String>() {{
                             put("userId", "javajigi");
                             put("password", "password");
                             put("name", "박재성");
                             put("email", "javajigi@slipp.net");
                         }}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getPath")
+    void getPath(String desc, GetMessage getMessage, String expectedPath) {
+        String actualPath = getMessage.getPath();
+
+        assertThat(actualPath).as("getPath" + desc)
+                .isEqualTo(expectedPath);
+    }
+
+    static Stream<Arguments> getPath() {
+        return Stream.of(
+                Arguments.of(
+                        "쿼리스트링이 없는 GET 메세지",
+                        new GetMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "GET",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "GET /user/create HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF
+                                )
+                        ),
+                        "/user/create"
+                ),
+                Arguments.of(
+                        "쿼리스트링이 포함된 GET 메세지 path를 출력할때도 쿼리스트링이 포함되지 않아야 함",
+                        new GetMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "GET",
+                                        "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF
+                                )
+                        ),
+                        "/user/create"
                 )
         );
     }

--- a/src/test/java/webserver/http/message/PostMessageTest.java
+++ b/src/test/java/webserver/http/message/PostMessageTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import webserver.Const;
 import webserver.http.Body;
-import webserver.http.attribute.Attributes;
 import webserver.http.header.RequestHeader;
 import webserver.http.startline.RequestLine;
 
@@ -161,6 +160,44 @@ class PostMessageTest {
                             put("name", "박재성");
                             put("email", "javajigi@slipp.net");
                         }}
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getRequestLine")
+    void getRequestLine(PostMessage postMessage, RequestLine expectedRequestLine) {
+        Assertions.assertThat(postMessage)
+                .extracting("requestLine")
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(expectedRequestLine);
+    }
+
+    static Stream<Arguments> getRequestLine() {
+        return Stream.of(
+                Arguments.of(
+                        new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Content-Length: 59" + Const.CRLF +
+                                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF),
+                                Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
+                        ),
+                        new RequestLine(
+                                new HashMap<String, String>() {{
+                                    put("method", "POST");
+                                    put("path", "/user/create");
+                                    put("protocolVersion", "HTTP/1.1");
+                                }}
+                        )
                 )
         );
     }

--- a/src/test/java/webserver/http/message/PostMessageTest.java
+++ b/src/test/java/webserver/http/message/PostMessageTest.java
@@ -1,12 +1,16 @@
 package webserver.http.message;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import webserver.Const;
 import webserver.http.Body;
+import webserver.http.attribute.Attributes;
 import webserver.http.header.RequestHeader;
+import webserver.http.startline.RequestLine;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -17,9 +21,7 @@ class PostMessageTest {
 
     @ParameterizedTest
     @MethodSource("getHeader")
-    void getHeader(String messageText, RequestHeader expectedRequestHeader) {
-        PostMessage postMessage = PostMessage.from(messageText);
-
+    void getHeader(PostMessage postMessage, RequestHeader expectedRequestHeader) {
         assertThat(postMessage)
                 .extracting("header")
                 .usingRecursiveFieldByFieldElementComparator()
@@ -29,23 +31,30 @@ class PostMessageTest {
     static Stream<Arguments> getHeader() {
         return Stream.of(
                 Arguments.of(
-                        "POST /user/create HTTP/1.1" + Const.CRLF +
-                        "Host: localhost:8080" + Const.CRLF +
-                        "Connection: keep-alive" + Const.CRLF +
-                        "Content-Length: 59" + Const.CRLF +
-                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                        "Accept: */*" + Const.CRLF +
-                        "" + Const.CRLF +
-                        "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + Const.CRLF,
+                        new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Content-Length: 59" + Const.CRLF +
+                                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF),
+                                Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
+                        ),
                         RequestHeader.from(
                                 //TODO: 텍스트가 아닌 객체를 생성해서 테스트 해볼 수 있을 듯 Request의 테스트 참고
                                 "POST /user/create HTTP/1.1" + Const.CRLF +
-                                "Host: localhost:8080" + Const.CRLF +
-                                "Connection: keep-alive" + Const.CRLF +
-                                "Content-Length: 59" + Const.CRLF +
-                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                                "Accept: */*" + Const.CRLF +
-                                "" + Const.CRLF
+                                        "Host: localhost:8080" + Const.CRLF +
+                                        "Connection: keep-alive" + Const.CRLF +
+                                        "Content-Length: 59" + Const.CRLF +
+                                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                        "Accept: */*" + Const.CRLF +
+                                        "" + Const.CRLF
                         )
                 )
         );
@@ -53,78 +62,105 @@ class PostMessageTest {
 
     @ParameterizedTest
     @MethodSource("getBody")
-    void getBody(String messageText, Body expectedBody) {
-        PostMessage postMessage = PostMessage.from(messageText);
-
+    void getBody(PostMessage postMessage, Body expectedBody) {
         assertThat(postMessage.getBody())
                 .isEqualToComparingFieldByFieldRecursively(expectedBody);
     }
 
     static Stream<Arguments> getBody() {
         return Stream.of(
-                Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
-                             "Host: localhost:8080" + Const.CRLF +
-                             "Connection: keep-alive" + Const.CRLF +
-                             "Content-Length: 59" + Const.CRLF +
-                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                             "Accept: */*" + Const.CRLF +
-                             "" + Const.CRLF +
-                             "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + Const.CRLF,
-                             Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net" + Const.CRLF)
-                ), Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
-                                "" + Const.CRLF +
-                                "",
+                Arguments.of(
+                        new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Content-Length: 59" + Const.CRLF +
+                                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF),
+                                Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
+                        ),
+                        Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
+                ), Arguments.of(
+                        new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from("POST /user/create HTTP/1.1"),
                                 Body.from("")
+                        ),
+                        Body.from("")
                 )
         );
     }
 
     @ParameterizedTest
     @MethodSource("getMethod")
-    void getMethod(String messageText, String expectedRequestMethod) {
-        PostMessage postMessage = PostMessage.from(messageText);
+    void getMethod(PostMessage postMessage, String expectedRequestMethod) {
         assertThat(postMessage.getMethod()).isEqualTo(expectedRequestMethod);
     }
 
     static Stream<Arguments> getMethod() {
         return Stream.of(
-                Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
-                             "Host: localhost:8080" + Const.CRLF +
-                             "Connection: keep-alive" + Const.CRLF +
-                             "Content-Length: 59" + Const.CRLF +
-                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                             "Accept: */*" + Const.CRLF +
-                             "" + Const.CRLF +
-                             "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                             "POST"
+                Arguments.of(
+                        new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Content-Length: 59" + Const.CRLF +
+                                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF),
+                                Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
+                        ),
+                        "POST"
                 )
         );
     }
 
     @ParameterizedTest
     @MethodSource("getParameters")
-    void getParameters(String messageText, Map<String, String> expectedParameters) {
-        PostMessage postMessage = PostMessage.from(messageText);
+    void getParameters(PostMessage postMessage, Map<String, String> expectedParameters) {
         assertThat(postMessage.getParameters())
                 .isEqualTo(expectedParameters);
     }
 
     static Stream<Arguments> getParameters() {
         return Stream.of(
-                Arguments.of("POST /user/create HTTP/1.1" + Const.CRLF +
-                             "Host: localhost:8080" + Const.CRLF +
-                             "Connection: keep-alive" + Const.CRLF +
-                             "Content-Length: 59" + Const.CRLF +
-                             "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                             "Accept: */*" + Const.CRLF +
-                             "" + Const.CRLF +
-                             "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                             new HashMap<String, String>() {{
-                                 put("userId", "javajigi");
-                                 put("password", "password");
-                                 put("name", "박재성");
-                                 put("email", "javajigi@slipp.net");
-                             }}
+                Arguments.of(
+                        new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "POST /user/create HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Content-Length: 59" + Const.CRLF +
+                                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF),
+                                Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
+                        ),
+                        new HashMap<String, String>() {{
+                            put("userId", "javajigi");
+                            put("password", "password");
+                            put("name", "박재성");
+                            put("email", "javajigi@slipp.net");
+                        }}
                 )
         );
     }

--- a/src/test/java/webserver/http/message/RequestMessageTest.java
+++ b/src/test/java/webserver/http/message/RequestMessageTest.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import webserver.Const;
+import webserver.http.Body;
+import webserver.http.header.RequestHeader;
+import webserver.http.startline.RequestLine;
 
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -21,20 +25,26 @@ class RequestMessageTest {
         return Stream.of(
                 Arguments.of(
                         "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
-                        "Host: localhost:8080" + Const.CRLF +
-                        "Connection: keep-alive" + Const.CRLF +
-                        "Content-Length: 59" + Const.CRLF +
-                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                        "Accept: */*" + Const.CRLF +
-                        "" + Const.CRLF,
-                        GetMessage.from(
-                                "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
                                 "Host: localhost:8080" + Const.CRLF +
                                 "Connection: keep-alive" + Const.CRLF +
                                 "Content-Length: 59" + Const.CRLF +
                                 "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
                                 "Accept: */*" + Const.CRLF +
-                                "" + Const.CRLF
+                                "" + Const.CRLF,
+                        new GetMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "GET",
+                                        "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from(
+                                        "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1" + Const.CRLF +
+                                                "Host: localhost:8080" + Const.CRLF +
+                                                "Connection: keep-alive" + Const.CRLF +
+                                                "Content-Length: 59" + Const.CRLF +
+                                                "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                                "Accept: */*" + Const.CRLF
+                                )
                         )
                 )
         );

--- a/src/test/java/webserver/http/message/RequestMessageTest.java
+++ b/src/test/java/webserver/http/message/RequestMessageTest.java
@@ -61,22 +61,26 @@ class RequestMessageTest {
         return Stream.of(
                 Arguments.of(
                         "POST /user/create HTTP/1.1" + Const.CRLF +
-                        "Host: localhost:8080" + Const.CRLF +
-                        "Connection: keep-alive" + Const.CRLF +
-                        "Content-Length: 59" + Const.CRLF +
-                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
-                        "Accept: */*" + Const.CRLF +
-                        "" + Const.CRLF +
-                        "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
-                        PostMessage.from(
-                                "POST /user/create HTTP/1.1" + Const.CRLF +
                                 "Host: localhost:8080" + Const.CRLF +
                                 "Connection: keep-alive" + Const.CRLF +
                                 "Content-Length: 59" + Const.CRLF +
                                 "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
                                 "Accept: */*" + Const.CRLF +
                                 "" + Const.CRLF +
-                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net"
+                                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net",
+                        new PostMessage(
+                                RequestLine.from(Arrays.asList(
+                                        "POST",
+                                        "/user/create",
+                                        "HTTP/1.1"
+                                )),
+                                RequestHeader.from("POST /user/create HTTP/1.1" + Const.CRLF +
+                                        "Host: localhost:8080" + Const.CRLF +
+                                        "Connection: keep-alive" + Const.CRLF +
+                                        "Content-Length: 59" + Const.CRLF +
+                                        "Content-Type: application/x-www-form-urlencoded" + Const.CRLF +
+                                        "Accept: */*"),
+                                Body.from("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
                         )
                 )
         );

--- a/src/test/java/webserver/http/message/ResponseMessageTest.java
+++ b/src/test/java/webserver/http/message/ResponseMessageTest.java
@@ -1,5 +1,6 @@
 package webserver.http.message;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -7,7 +8,9 @@ import webserver.Const;
 import webserver.http.Body;
 import webserver.http.header.Header;
 import webserver.http.header.ResponseHeader;
+import webserver.http.startline.StatusLine;
 
+import java.util.HashMap;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -88,6 +91,33 @@ class ResponseMessageTest {
                         Body.from("Hello World" + Const.CRLF +
                                   Const.CRLF +
                                   "Bye World")
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("getStatusLine")
+    void getStatusLine(String responseText, StatusLine expectedStatusLine) {
+        Assertions.assertThat(ResponseMessage.from(responseText))
+                .extracting("statusLine")
+                .usingRecursiveFieldByFieldElementComparator()
+                .contains(expectedStatusLine);
+    }
+
+    static Stream<Arguments> getStatusLine() {
+        return Stream.of(
+                Arguments.of(
+                        "HTTP/1.1 200 OK" + Const.CRLF +
+                                "Content-Type: text/html;charset=utf-8" + Const.CRLF +
+                                "Content-Length: " + "Hello World" .getBytes().length + Const.CRLF +
+                                Const.CRLF,
+                        new StatusLine(
+                                new HashMap() {{
+                                    put("protocolVersion", "HTTP/1.1");
+                                    put("statusText", "OK");
+                                    put("statusCode", "200");
+                                }}
+                        )
                 )
         );
     }


### PR DESCRIPTION
header에 있는 start line을 message로 옮겨줬습니다.
작업을 하면서 테스트도 함께 이동하는 경우가 많았습니다.
별도의 테스트 추가는 거의 없었던 것 같아요

작업이 생각보다 오래 걸린건 GetMessage와 PostMessage가 RequestMessage를 상속받는 구조의 복잡성 때문이었던 것 같아요 -> Header와 RequestHeader, ResponseHeader를 상속받는 구조
앞으로 상속구조를 만들때는 신중하게 결정해야겠네요